### PR TITLE
Implement basic Telegram bot with VIP and admin menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Botmaestro
+
+Este repositorio contiene un ejemplo b\u00e1sico de un bot de Telegram con tres flujos principales:
+
+1. **Men\u00fa de Administrador** para usuarios con privilegios.
+2. **Men\u00fa de suscriptores VIP** que incluye la base de un sistema de gamificaci\u00f3n.
+3. **Men\u00fa de suscripci\u00f3n** para usuarios del canal gratuito.
+
+El bot est\u00e1 desarrollado con `python-telegram-bot`. Para probarlo localmente sigue estos pasos:
+
+```bash
+pip install python-telegram-bot==13.15
+python bot.py
+```
+
+Antes de ejecutar, reemplaza `YOUR_TELEGRAM_BOT_TOKEN` en `bot.py` con el token real de tu bot y actualiza las listas `ADMIN_IDS` y `VIP_USERS` con los identificadores correspondientes.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,41 @@
+import logging
+from telegram import Update, ReplyKeyboardMarkup
+from telegram.ext import Updater, CommandHandler, CallbackContext
+
+# IDs hardcoded for demonstration. Replace with database or persistent storage.
+ADMIN_IDS = {123456789}  # Reemplaza con el ID real del administrador
+VIP_USERS = {987654321}  # Reemplaza con IDs de usuarios VIP
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def start(update: Update, context: CallbackContext) -> None:
+    user_id = update.effective_user.id
+    if user_id in ADMIN_IDS:
+        reply_text = "\u2728 Men\u00fa de Administrador \u2728"
+        keyboard = [["Estad\u00edsticas"], ["Gestionar VIPs"]]
+    elif user_id in VIP_USERS:
+        reply_text = "\ud83c\udf81 Men\u00fa VIP \ud83c\udf81"
+        keyboard = [["Jugar"], ["Mi Progreso"]]
+    else:
+        reply_text = "\ud83d\udc65 Men\u00fa de Suscripci\u00f3n \ud83d\udc65"
+        keyboard = [["Suscribirme"], ["Info del Canal"]]
+
+    markup = ReplyKeyboardMarkup(keyboard, one_time_keyboard=True, resize_keyboard=True)
+    update.message.reply_text(reply_text, reply_markup=markup)
+
+
+def main() -> None:
+    # Coloca tu token de bot aqu\u00ed
+    TOKEN = "YOUR_TELEGRAM_BOT_TOKEN"
+    updater = Updater(TOKEN)
+
+    dispatcher = updater.dispatcher
+    dispatcher.add_handler(CommandHandler("start", start))
+
+    updater.start_polling()
+    updater.idle()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add initial Telegram bot with separate menus for admin, VIP, and free users
- document how to run the bot and install dependencies

## Testing
- `python -m py_compile bot.py`
- `pip install python-telegram-bot==13.15`

------
https://chatgpt.com/codex/tasks/task_e_684e0d53fae48329a57ecb7362ed3f7d