### PR TITLE
Fix invalid token error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Botmaestro
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Export your Telegram bot token in the `BOT_TOKEN` environment variable:
+
+   ```bash
+   export BOT_TOKEN="<your_bot_token>"
+   ```
+
+3. Run the bot:
+
+   ```bash
+   python mybot/bot.py
+   ```

--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -1,8 +1,17 @@
-from dataclasses import dataclass
+import os
 from typing import List
 
-# Replace with your real bot token
-BOT_TOKEN = "YOUR_BOT_TOKEN"
+# Obtain the Telegram bot token from the ``BOT_TOKEN`` environment
+# variable. This avoids hard coding sensitive information in the
+# source code. If the variable is missing or still set to the
+# placeholder value, raise an explicit error so the user knows what to
+# do.
+BOT_TOKEN = os.environ.get("BOT_TOKEN", "YOUR_BOT_TOKEN")
+
+if BOT_TOKEN == "YOUR_BOT_TOKEN" or not BOT_TOKEN:
+    raise ValueError(
+        "BOT_TOKEN environment variable is not set or contains the default placeholder."
+    )
 
 # Telegram user IDs of admins
 ADMIN_IDS: List[int] = [123456789]


### PR DESCRIPTION
## Summary
- load `BOT_TOKEN` from environment to avoid placeholder token
- document setup instructions for setting `BOT_TOKEN`

## Testing
- `pip install -r requirements.txt`
- `python mybot/bot.py` *(fails: BOT_TOKEN environment variable is not set or contains the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_684e16dfb4d08329804efecd1ba5b904