### PR TITLE
Fix aiogram 3.7 bot initialization

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -1,13 +1,14 @@
 import asyncio
 from aiogram import Bot, Dispatcher
 from aiogram.enums.parse_mode import ParseMode
+from aiogram.client.bot import DefaultBotProperties
 
 from handlers import start, admin, vip, free_user
 from utils.config import BOT_TOKEN
 
 
 async def main() -> None:
-    bot = Bot(BOT_TOKEN, parse_mode=ParseMode.HTML)
+    bot = Bot(BOT_TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
     dp = Dispatcher()
 
     dp.include_router(start.router)


### PR DESCRIPTION
## Summary
- adapt bot initialization to new aiogram API

## Testing
- `python -m py_compile mybot/bot.py`
- `python - <<'PY'
import aiogram
print('aiogram version:', aiogram.__version__)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684e17cce8988329845eec0c1c879227