### PR TITLE
Add role-specific menus

### DIFF
--- a/mybot/handlers/admin.py
+++ b/mybot/handlers/admin.py
@@ -12,9 +12,9 @@ router = Router()
 async def admin_menu(message: Message):
     if not is_admin(message.from_user.id):
         return
-    await message.answer("Admin menu", reply_markup=get_admin_kb())
+    await message.answer("Menú de administración", reply_markup=get_admin_kb())
 
 
-@router.callback_query(F.data == "admin_placeholder")
+@router.callback_query(F.data == "admin_button")
 async def admin_placeholder_handler(callback: CallbackQuery):
-    await callback.answer("Admin action placeholder")
+    await callback.answer("Acción de administración")

--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -12,9 +12,12 @@ router = Router()
 async def subscription_menu(message: Message):
     if is_admin(message.from_user.id) or is_vip(message.from_user.id):
         return
-    await message.answer("Subscription menu", reply_markup=get_subscription_kb())
+    await message.answer(
+        "Menú para usuarios del canal free",
+        reply_markup=get_subscription_kb(),
+    )
 
 
-@router.callback_query(F.data == "request_access")
+@router.callback_query(F.data == "free_button")
 async def request_access(callback: CallbackQuery):
-    await callback.answer("Request sent", show_alert=True)
+    await callback.answer("Acceso solicitado", show_alert=True)

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -14,11 +14,17 @@ router = Router()
 async def cmd_start(message: Message):
     user_id = message.from_user.id
     if is_admin(user_id):
-        await message.answer("Welcome, admin!", reply_markup=get_admin_kb())
+        await message.answer(
+            "Bienvenido, administrador!",
+            reply_markup=get_admin_kb(),
+        )
     elif is_vip(user_id):
-        await message.answer("Welcome, VIP subscriber!", reply_markup=get_vip_kb())
+        await message.answer(
+            "Bienvenido, suscriptor VIP!",
+            reply_markup=get_vip_kb(),
+        )
     else:
         await message.answer(
-            "Welcome! Please consider subscribing.",
+            "Bienvenido al canal free!",
             reply_markup=get_subscription_kb(),
         )

--- a/mybot/handlers/vip.py
+++ b/mybot/handlers/vip.py
@@ -12,9 +12,9 @@ router = Router()
 async def vip_menu(message: Message):
     if not is_vip(message.from_user.id):
         return
-    await message.answer("VIP menu", reply_markup=get_vip_kb())
+    await message.answer("Menú para suscriptores VIP", reply_markup=get_vip_kb())
 
 
-@router.callback_query(F.data == "vip_placeholder")
+@router.callback_query(F.data == "vip_button")
 async def vip_placeholder_handler(callback: CallbackQuery):
-    await callback.answer("VIP action placeholder")
+    await callback.answer("Acción de suscriptor VIP")

--- a/mybot/keyboards/admin_kb.py
+++ b/mybot/keyboards/admin_kb.py
@@ -2,6 +2,9 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
 def get_admin_kb():
+    """Return a minimal admin menu."""
+
     builder = InlineKeyboardBuilder()
-    builder.button(text="Admin Placeholder", callback_data="admin_placeholder")
+    # Single button for the admin menu
+    builder.button(text="Botón de administración", callback_data="admin_button")
     return builder.as_markup()

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -2,6 +2,9 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
 def get_subscription_kb():
+    """Return a minimal free-user menu."""
+
     builder = InlineKeyboardBuilder()
-    builder.button(text="Request Access", callback_data="request_access")
+    # Single button for free channel subscribers or access requests
+    builder.button(text="Botón de suscriptor free", callback_data="free_button")
     return builder.as_markup()

--- a/mybot/keyboards/vip_kb.py
+++ b/mybot/keyboards/vip_kb.py
@@ -2,6 +2,9 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
 def get_vip_kb():
+    """Return a minimal VIP subscriber menu."""
+
     builder = InlineKeyboardBuilder()
-    builder.button(text="VIP Placeholder", callback_data="vip_placeholder")
+    # Single button for VIP subscribers
+    builder.button(text="Botón de suscriptor VIP", callback_data="vip_button")
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- implement custom keyboards for admin, VIP and free users
- update handlers to use new keyboards and show messages in Spanish
- simplify `cmd_start` to display the proper menu for each role

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `python mybot/bot.py` *(fails: BOT_TOKEN environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_684e1faaaaec8329aca798886f744f82