### PR TITLE
Add basic VIP gamification module

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -4,6 +4,7 @@ from aiogram.enums.parse_mode import ParseMode
 from aiogram.client.bot import DefaultBotProperties
 
 from handlers import start, admin, vip, free_user
+from handlers.vip import gamification
 from utils.config import BOT_TOKEN
 
 
@@ -14,6 +15,7 @@ async def main() -> None:
     dp.include_router(start.router)
     dp.include_router(admin.router)
     dp.include_router(vip.router)
+    dp.include_router(gamification.router)
     dp.include_router(free_user.router)
 
     await dp.start_polling(bot)

--- a/mybot/handlers/__init__.py
+++ b/mybot/handlers/__init__.py
@@ -1,0 +1,10 @@
+from . import admin, free_user, start, vip
+from .vip import gamification
+
+__all__ = [
+    "admin",
+    "free_user",
+    "start",
+    "vip",
+    "gamification",
+]

--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -1,0 +1,55 @@
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery
+from aiogram.filters import Command
+
+from keyboards.vip_game_kb import (
+    get_vip_game_menu_kb,
+    get_vip_profile_kb,
+)
+from utils.user_roles import is_vip
+from services.point_service import add_points, get_user_points
+from services.level_service import get_user_level, check_for_level_up
+
+router = Router()
+
+# Apply VIP filter at router level
+router.message.filter(lambda m: is_vip(m.from_user.id))
+router.callback_query.filter(lambda c: is_vip(c.from_user.id))
+
+
+@router.message(Command("game_menu"))
+async def game_menu(message: Message):
+    await message.answer("\U0001F3AE Menú de juego VIP", reply_markup=get_vip_game_menu_kb())
+
+
+@router.callback_query(F.data == "vip_game_menu")
+async def callback_game_menu(callback: CallbackQuery):
+    await callback.message.edit_text(
+        "\U0001F3AE Menú de juego VIP",
+        reply_markup=get_vip_game_menu_kb(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_gain_points")
+async def callback_gain_points(callback: CallbackQuery):
+    user_id = callback.from_user.id
+    points = add_points(user_id, 10)
+    leveled_up, level = check_for_level_up(user_id)
+    text = f"Sumaste 10 puntos. Total: {points}."
+    if leveled_up:
+        text += f"\n\n✨ ¡Felicidades! Nivel {level}."
+    await callback.answer(text, show_alert=True)
+
+
+@router.callback_query(F.data == "vip_profile")
+async def callback_profile(callback: CallbackQuery):
+    user_id = callback.from_user.id
+    points = get_user_points(user_id)
+    level = get_user_level(user_id)
+    profile_text = (
+        "\U0001F4C8 Perfil VIP\n\n"
+        f"Puntos: {points}\nNivel: {level}"
+    )
+    await callback.message.edit_text(profile_text, reply_markup=get_vip_profile_kb())
+    await callback.answer()

--- a/mybot/keyboards/__init__.py
+++ b/mybot/keyboards/__init__.py
@@ -1,0 +1,12 @@
+from .admin_kb import get_admin_kb
+from .subscription_kb import get_subscription_kb
+from .vip_kb import get_vip_kb
+from .vip_game_kb import get_vip_game_menu_kb, get_vip_profile_kb
+
+__all__ = [
+    "get_admin_kb",
+    "get_subscription_kb",
+    "get_vip_kb",
+    "get_vip_game_menu_kb",
+    "get_vip_profile_kb",
+]

--- a/mybot/keyboards/vip_game_kb.py
+++ b/mybot/keyboards/vip_game_kb.py
@@ -1,0 +1,15 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_vip_game_menu_kb():
+    """Keyboard for the VIP game menu."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="\U0001F4CA Perfil", callback_data="vip_profile")
+    builder.button(text="\U0001F381 Obtener Puntos", callback_data="vip_gain_points")
+    return builder.as_markup()
+
+
+def get_vip_profile_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="\u2b05\ufe0f Volver", callback_data="vip_game_menu")
+    return builder.as_markup()

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -1,0 +1,15 @@
+"""Simple in-memory services used for VIP gamification."""
+
+from .point_service import add_points, get_user_points
+from .level_service import get_user_level, check_for_level_up
+from .achievement_service import grant_achievement, get_user_achievements, ACHIEVEMENTS
+
+__all__ = [
+    "add_points",
+    "get_user_points",
+    "get_user_level",
+    "check_for_level_up",
+    "grant_achievement",
+    "get_user_achievements",
+    "ACHIEVEMENTS",
+]

--- a/mybot/services/achievement_service.py
+++ b/mybot/services/achievement_service.py
@@ -1,0 +1,21 @@
+"""Minimal achievement tracking."""
+
+from typing import Dict, Set
+
+ACHIEVEMENTS = {
+    "first_points": "Primeros Puntos"
+}
+
+_user_achievements: Dict[int, Set[str]] = {}
+
+
+def grant_achievement(user_id: int, achievement_id: str) -> bool:
+    achievements = _user_achievements.setdefault(user_id, set())
+    if achievement_id in achievements:
+        return False
+    achievements.add(achievement_id)
+    return True
+
+
+def get_user_achievements(user_id: int) -> Set[str]:
+    return _user_achievements.get(user_id, set())

--- a/mybot/services/level_service.py
+++ b/mybot/services/level_service.py
@@ -1,0 +1,36 @@
+"""Simple level calculation service."""
+
+from typing import Dict
+from .point_service import get_user_points
+
+# Cumulative points needed to reach each level
+LEVEL_THRESHOLDS = {
+    1: 0,
+    2: 10,
+    3: 25,
+    4: 50,
+    5: 100,
+    6: 200,
+    7: 350,
+    8: 550,
+    9: 800,
+    10: 1100,
+}
+
+_user_levels: Dict[int, int] = {}
+
+
+def get_user_level(user_id: int) -> int:
+    return _user_levels.get(user_id, 1)
+
+
+def check_for_level_up(user_id: int) -> tuple[bool, int]:
+    """Check and apply level ups. Returns (leveled_up, new_level)."""
+    points = get_user_points(user_id)
+    level = _user_levels.get(user_id, 1)
+    leveled_up = False
+    while points >= LEVEL_THRESHOLDS.get(level + 1, float("inf")):
+        level += 1
+        leveled_up = True
+    _user_levels[user_id] = level
+    return leveled_up, level

--- a/mybot/services/point_service.py
+++ b/mybot/services/point_service.py
@@ -1,0 +1,17 @@
+"""In-memory point tracking service."""
+
+from typing import Dict
+
+_user_points: Dict[int, int] = {}
+
+
+def add_points(user_id: int, points: int) -> int:
+    """Add points to a user and return new total."""
+    current = _user_points.get(user_id, 0) + points
+    _user_points[user_id] = current
+    return current
+
+
+def get_user_points(user_id: int) -> int:
+    """Return user points."""
+    return _user_points.get(user_id, 0)


### PR DESCRIPTION
## Summary
- start integrating old gamification features
- add VIP gamification handlers
- provide simple in-memory services for points, levels and achievements
- create new keyboards for VIP game menu
- update dispatcher to include gamification router

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e24e665148329ab1bf22057eac23f