### PR TITLE
Refactor admin menu with subrouters

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -6,8 +6,9 @@ from aiogram.fsm.storage.memory import MemoryStorage
 
 from database.setup import init_db, get_session
 
-from handlers import start, admin, free_user
-from handlers.vip import menu as vip, gamification
+from handlers import start, free_user
+from handlers.vip import menu as vip
+from handlers.admin import admin_router, vip_router, free_router as admin_free_router, config_router
 from utils.config import BOT_TOKEN
 
 
@@ -30,9 +31,11 @@ async def main() -> None:
     dp.callback_query.outer_middleware(session_middleware_factory(Session, bot))
 
     dp.include_router(start.router)
-    dp.include_router(admin.router)
+    dp.include_router(admin_router)
     dp.include_router(vip.router)
-    dp.include_router(gamification.router)
+    dp.include_router(vip_router)
+    dp.include_router(admin_free_router)
+    dp.include_router(config_router)
     dp.include_router(free_user.router)
 
     await dp.start_polling(bot)

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -1,0 +1,11 @@
+from .admin_menu import router as admin_router
+from .vip_menu import router as vip_router
+from .free_menu import router as free_router
+from .config_menu import router as config_router
+
+__all__ = [
+    "admin_router",
+    "vip_router",
+    "free_router",
+    "config_router",
+]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -1,0 +1,52 @@
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery
+from aiogram.filters import CommandStart, Command
+
+from keyboards.admin_main_kb import get_admin_main_kb
+from utils.user_roles import is_admin
+from utils.keyboard_utils import get_main_menu_keyboard
+from utils.messages import BOT_MESSAGES
+
+from .vip_menu import router as vip_router
+from .free_menu import router as free_router
+from .config_menu import router as config_router
+from handlers.vip.gamification import router as game_router
+
+router = Router()
+router.include_router(vip_router)
+router.include_router(free_router)
+router.include_router(config_router)
+router.include_router(game_router)
+
+
+@router.message(CommandStart())
+async def admin_start(message: Message):
+    if not is_admin(message.from_user.id):
+        return
+    await message.answer("Men\u00fa de administraci\u00f3n", reply_markup=get_admin_main_kb())
+
+
+@router.message(Command("admin_menu"))
+async def admin_menu(message: Message):
+    if not is_admin(message.from_user.id):
+        return
+    await message.answer("Men\u00fa de administraci\u00f3n", reply_markup=get_admin_main_kb())
+
+
+@router.callback_query(F.data == "admin_game")
+async def admin_game_entry(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        BOT_MESSAGES["start_welcome_returning_user"],
+        reply_markup=get_main_menu_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_back")
+async def admin_back(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.delete()
+    await callback.answer()

--- a/mybot/handlers/admin/config_menu.py
+++ b/mybot/handlers/admin/config_menu.py
@@ -1,0 +1,14 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+from utils.user_roles import is_admin
+
+router = Router()
+
+
+@router.callback_query(F.data == "admin_config")
+async def config_menu(callback: CallbackQuery):
+    """Placeholder bot configuration menu."""
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text("Configuraci\u00f3n del bot en construcci\u00f3n")
+    await callback.answer()

--- a/mybot/handlers/admin/free_menu.py
+++ b/mybot/handlers/admin/free_menu.py
@@ -1,0 +1,14 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+from utils.user_roles import is_admin
+
+router = Router()
+
+
+@router.callback_query(F.data == "admin_free")
+async def free_menu(callback: CallbackQuery):
+    """Placeholder Free channel admin menu."""
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text("Secci\u00f3n Free en construcci\u00f3n")
+    await callback.answer()

--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -1,0 +1,14 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+from utils.user_roles import is_admin
+
+router = Router()
+
+
+@router.callback_query(F.data == "admin_vip")
+async def vip_menu(callback: CallbackQuery):
+    """Placeholder VIP admin menu."""
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text("Secci\u00f3n VIP en construcci\u00f3n")
+    await callback.answer()

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -2,7 +2,7 @@ from aiogram import Router
 from aiogram.filters import CommandStart
 from aiogram.types import Message
 
-from keyboards.admin_kb import get_admin_kb
+from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_kb import get_vip_kb
 from keyboards.subscription_kb import get_subscription_kb
 from utils.user_roles import is_admin, is_vip
@@ -16,7 +16,7 @@ async def cmd_start(message: Message):
     if is_admin(user_id):
         await message.answer(
             "Bienvenido, administrador!",
-            reply_markup=get_admin_kb(),
+            reply_markup=get_admin_main_kb(),
         )
     elif await is_vip(message.bot, user_id):
         await message.answer(

--- a/mybot/keyboards/admin_main_kb.py
+++ b/mybot/keyboards/admin_main_kb.py
@@ -1,0 +1,13 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_main_kb():
+    """Return the main admin inline keyboard."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📢 Canal VIP", callback_data="admin_vip")
+    builder.button(text="💬 Canal Free", callback_data="admin_free")
+    builder.button(text="🎮 Juego Kinky", callback_data="admin_game")
+    builder.button(text="🛠 Configuración del Bot", callback_data="admin_config")
+    builder.button(text="🔙 Volver", callback_data="admin_back")
+    builder.adjust(1)
+    return builder.as_markup()


### PR DESCRIPTION
## Summary
- add new admin inline keyboard with VIP, Free, Juego Kinky and Config options
- create admin routers for VIP, Free, Config and main menu
- connect gamification router only through Juego Kinky
- wire new routers in bot startup and update /start for admins

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || echo 'flake8 not installed'`
- `pytest || echo 'pytest not installed'`


------
https://chatgpt.com/codex/tasks/task_e_684e4c91b7408329891e4d749c258502