### PR TITLE
Fix duplicate router inclusion

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -8,7 +8,7 @@ from database.setup import init_db, get_session
 
 from handlers import start, free_user
 from handlers.vip import menu as vip
-from handlers.admin import admin_router, vip_router, free_router as admin_free_router, config_router
+from handlers.admin import admin_router
 from utils.config import BOT_TOKEN
 
 
@@ -33,9 +33,6 @@ async def main() -> None:
     dp.include_router(start.router)
     dp.include_router(admin_router)
     dp.include_router(vip.router)
-    dp.include_router(vip_router)
-    dp.include_router(admin_free_router)
-    dp.include_router(config_router)
     dp.include_router(free_user.router)
 
     await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- only import admin_router
- rely on admin_router's subrouters to avoid duplicates

## Testing
- `python -m py_compile mybot/bot.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e4e30a3ec832985be8159f10509f1