### PR TITLE
Implement role-aware menus and VIP management

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -67,6 +67,35 @@ class Event(AsyncAttrs, Base):
     created_at = Column(DateTime, default=func.now())
 
 
+class Subscription(AsyncAttrs, Base):
+    """User subscription periods for the VIP channel."""
+
+    __tablename__ = "subscriptions"
+
+    user_id = Column(BigInteger, primary_key=True)
+    start_date = Column(DateTime, nullable=False)
+    end_date = Column(DateTime, nullable=False)
+
+
+class Token(AsyncAttrs, Base):
+    """Invitation tokens used to activate a subscription."""
+
+    __tablename__ = "tokens"
+
+    token = Column(String, primary_key=True, unique=True)
+    duration_days = Column(Integer, nullable=False)
+    used = Column(Boolean, default=False)
+
+
+class Config(AsyncAttrs, Base):
+    """Key/value configuration storage for VIP features."""
+
+    __tablename__ = "config"
+
+    key = Column(String, primary_key=True)
+    value = Column(String, nullable=False)
+
+
 # Funciones para manejar el estado del menú del usuario
 async def get_user_menu_state(session, user_id: int) -> str:
     result = await session.execute(select(User).where(User.id == user_id))

--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -1,14 +1,107 @@
 from aiogram import Router, F
-from aiogram.types import CallbackQuery
-from utils.user_roles import is_admin
+from aiogram.types import CallbackQuery, Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.user_roles import is_admin, is_vip_member
+from keyboards.admin_vip_kb import (
+    get_admin_vip_kb,
+    get_vip_admin_tools_kb,
+    get_vip_admin_settings_kb,
+)
+from keyboards.vip_kb import get_vip_kb
+from services import SubscriptionService, TokenService, ConfigService
 
 router = Router()
 
+# Temporary store when an admin is entering a price
+_waiting_price: dict[int, str] = {}
+
 
 @router.callback_query(F.data == "admin_vip")
-async def vip_menu(callback: CallbackQuery):
-    """Placeholder VIP admin menu."""
+async def vip_menu(callback: CallbackQuery, session: AsyncSession):
+    user_id = callback.from_user.id
+    if is_admin(user_id):
+        await callback.message.edit_text("Adm. Diván", reply_markup=get_admin_vip_kb())
+        await callback.answer()
+        return
+
+    if await is_vip_member(callback.bot, user_id):
+        service = SubscriptionService(session)
+        sub = await service.get_subscription(user_id)
+        text = (
+            f"Suscripción activa hasta {sub.end_date.date()}"
+            if sub
+            else "No tienes una suscripción activa."
+        )
+        await callback.message.edit_text(text, reply_markup=get_vip_kb())
+        await callback.answer()
+        return
+
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_admin_tools")
+async def vip_admin_tools(callback: CallbackQuery):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
-    await callback.message.edit_text("Secci\u00f3n VIP en construcci\u00f3n")
+    await callback.message.edit_text("Administración", reply_markup=get_vip_admin_tools_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_admin_config")
+async def vip_admin_config(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text("Configuración", reply_markup=get_vip_admin_settings_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("vip_price:"))
+async def vip_set_price_period(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    period = callback.data.split(":", 1)[1]
+    _waiting_price[callback.from_user.id] = period
+    await callback.message.edit_text("Ingresa el precio para este período")
+    await callback.answer()
+
+
+@router.message(lambda m: m.from_user and m.from_user.id in _waiting_price)
+async def vip_price_input(message: Message, session: AsyncSession):
+    user_id = message.from_user.id
+    period = _waiting_price.pop(user_id, None)
+    if period is None:
+        return
+    if not message.text.isdigit():
+        await message.answer("Ingresa solo números")
+        return
+    service = ConfigService(session)
+    await service.set_price(period, message.text.strip())
+    await message.answer("Precio actualizado")
+
+
+@router.callback_query(F.data == "vip_admin_gen_link")
+async def vip_admin_gen_link(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    tokens = TokenService(session)
+    token = await tokens.generate_token(7)
+    bot_username = (await callback.bot.me()).username
+    link = f"https://t.me/{bot_username}?start={token}"
+    await callback.message.edit_text(f"Enlace generado: {link}", reply_markup=get_vip_admin_tools_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_admin_list")
+async def vip_admin_list(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    service = SubscriptionService(session)
+    subs = await service.list_active_subscriptions()
+    if not subs:
+        await callback.message.edit_text("No hay suscriptores activos", reply_markup=get_vip_admin_tools_kb())
+        await callback.answer()
+        return
+    text = "\n".join([f"{sub.user_id} → {sub.end_date.date()}" for sub in subs])
+    await callback.message.edit_text(text, reply_markup=get_vip_admin_tools_kb())
     await callback.answer()

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -5,7 +5,7 @@ from aiogram.types import Message
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_kb import get_vip_kb
 from keyboards.subscription_kb import get_subscription_kb
-from utils.user_roles import is_admin, is_vip
+from utils.user_roles import is_admin, is_vip_member
 
 router = Router()
 
@@ -18,13 +18,13 @@ async def cmd_start(message: Message):
             "Bienvenido, administrador!",
             reply_markup=get_admin_main_kb(),
         )
-    elif await is_vip(message.bot, user_id):
+    elif await is_vip_member(message.bot, user_id):
         await message.answer(
             "Bienvenido, suscriptor VIP!",
             reply_markup=get_vip_kb(),
         )
     else:
         await message.answer(
-            "Bienvenido al canal free!",
+            "Para acceder al canal VIP necesitas una suscripción.",
             reply_markup=get_subscription_kb(),
         )

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -2,19 +2,32 @@ from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery
 from aiogram.filters import Command
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from keyboards.vip_kb import get_vip_kb
-from utils.user_roles import is_vip
+from utils.user_roles import is_vip_member
+from services.subscription_service import SubscriptionService
 
 router = Router()
 
 
 @router.message(Command("vip_menu"))
-async def vip_menu(message: Message):
-    if not await is_vip(message.bot, message.from_user.id):
+async def vip_menu(message: Message, session: AsyncSession):
+    if not await is_vip_member(message.bot, message.from_user.id):
         return
     await message.answer("Menú para suscriptores VIP", reply_markup=get_vip_kb())
 
 
-@router.callback_query(F.data == "vip_button")
-async def vip_placeholder_handler(callback: CallbackQuery):
-    await callback.answer("Acción de suscriptor VIP")
+@router.callback_query(F.data == "vip_subscription")
+async def vip_subscription(callback: CallbackQuery, session: AsyncSession):
+    if not await is_vip_member(callback.bot, callback.from_user.id):
+        return await callback.answer()
+
+    service = SubscriptionService(session)
+    sub = await service.get_subscription(callback.from_user.id)
+    if sub:
+        text = f"Suscripción activa hasta {sub.end_date.date()}"
+    else:
+        text = "No tienes una suscripción activa."
+    await callback.message.edit_text(text, reply_markup=get_vip_kb())
+    await callback.answer()

--- a/mybot/keyboards/admin_vip_kb.py
+++ b/mybot/keyboards/admin_vip_kb.py
@@ -1,0 +1,41 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_vip_kb():
+    """Keyboard for VIP administration menu."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Administración", callback_data="vip_admin_tools")
+    builder.button(text="Configuración", callback_data="vip_admin_config")
+    builder.button(text="🔙 Volver", callback_data="admin_back")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_vip_admin_tools_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📊 Estadísticas", callback_data="vip_admin_stats")
+    builder.button(text="🔗 Generar enlace", callback_data="vip_admin_gen_link")
+    builder.button(text="👥 Suscriptores", callback_data="vip_admin_list")
+    builder.button(text="🔙 Volver", callback_data="admin_vip")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_vip_admin_settings_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Definir precio", callback_data="vip_admin_set_price")
+    builder.button(text="🔙 Volver", callback_data="admin_vip")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_price_period_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="1 día", callback_data="vip_price:1d")
+    builder.button(text="1 semana", callback_data="vip_price:1w")
+    builder.button(text="2 semanas", callback_data="vip_price:2w")
+    builder.button(text="1 mes", callback_data="vip_price:1m")
+    builder.button(text="Permanente", callback_data="vip_price:perm")
+    builder.button(text="🔙 Volver", callback_data="vip_admin_config")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/vip_kb.py
+++ b/mybot/keyboards/vip_kb.py
@@ -2,9 +2,10 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
 def get_vip_kb():
-    """Return a minimal VIP subscriber menu."""
+    """Return the VIP user menu keyboard."""
 
     builder = InlineKeyboardBuilder()
-    # Single button for VIP subscribers
-    builder.button(text="Botón de suscriptor VIP", callback_data="vip_button")
+    builder.button(text="🧾 Mi Suscripción", callback_data="vip_subscription")
+    builder.button(text="🎮 Juego del Diván", callback_data="menu_principal")
+    builder.adjust(1)
     return builder.as_markup()

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -1,0 +1,19 @@
+from .subscription_service import SubscriptionService
+from .token_service import TokenService
+from .config_service import ConfigService
+from .point_service import PointService
+from .level_service import LevelService
+from .achievement_service import AchievementService
+from .mission_service import MissionService
+from .reward_service import RewardService
+
+__all__ = [
+    "SubscriptionService",
+    "TokenService",
+    "ConfigService",
+    "PointService",
+    "LevelService",
+    "AchievementService",
+    "MissionService",
+    "RewardService",
+]

--- a/mybot/services/config_service.py
+++ b/mybot/services/config_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from database.models import Config
+
+
+class ConfigService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_config(self, key: str) -> str | None:
+        stmt = select(Config).where(Config.key == key)
+        result = await self.session.execute(stmt)
+        config = result.scalar_one_or_none()
+        return config.value if config else None
+
+    async def set_config(self, key: str, value: str) -> None:
+        cfg = await self.session.get(Config, key)
+        if cfg:
+            cfg.value = value
+        else:
+            cfg = Config(key=key, value=value)
+            self.session.add(cfg)
+        await self.session.commit()
+
+    async def get_pricing(self) -> tuple[str, str] | None:
+        period = await self.get_config("price_period")
+        amount = await self.get_config("price_amount")
+        if period is None or amount is None:
+            return None
+        return period, amount
+
+    async def set_pricing(self, period: str, amount: str) -> None:
+        await self.set_config("price_period", period)
+        await self.set_config("price_amount", amount)
+
+    async def set_price(self, period: str, amount: str) -> None:
+        await self.set_config(f"price_{period}", amount)
+
+    async def get_price(self, period: str) -> str | None:
+        return await self.get_config(f"price_{period}")

--- a/mybot/services/subscription_service.py
+++ b/mybot/services/subscription_service.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from database.models import Subscription
+
+
+class SubscriptionService:
+    """Manage VIP channel subscriptions."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def add_subscription(self, user_id: int, duration_days: int) -> Subscription:
+        now = datetime.utcnow()
+        sub = await self.session.get(Subscription, user_id)
+        if sub:
+            if sub.end_date < now:
+                sub.start_date = now
+                sub.end_date = now + timedelta(days=duration_days)
+            else:
+                sub.end_date = sub.end_date + timedelta(days=duration_days)
+        else:
+            sub = Subscription(
+                user_id=user_id,
+                start_date=now,
+                end_date=now + timedelta(days=duration_days),
+            )
+            self.session.add(sub)
+        await self.session.commit()
+        await self.session.refresh(sub)
+        return sub
+
+    async def get_subscription(self, user_id: int) -> Subscription | None:
+        return await self.session.get(Subscription, user_id)
+
+    async def remove_subscription(self, user_id: int) -> None:
+        sub = await self.session.get(Subscription, user_id)
+        if sub:
+            await self.session.delete(sub)
+            await self.session.commit()
+
+    async def list_active_subscriptions(self) -> list[Subscription]:
+        now = datetime.utcnow()
+        stmt = select(Subscription).where(Subscription.end_date > now)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()

--- a/mybot/services/token_service.py
+++ b/mybot/services/token_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import secrets
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import Token
+
+
+class TokenService:
+    """Generate and validate invitation tokens."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def generate_token(self, duration_days: int) -> str:
+        while True:
+            token = secrets.token_urlsafe(8)
+            existing = await self.session.get(Token, token)
+            if existing:
+                continue
+            self.session.add(Token(token=token, duration_days=duration_days))
+            await self.session.commit()
+            return token
+
+    async def validate_token(self, token: str) -> int | None:
+        obj = await self.session.get(Token, token)
+        if not obj or obj.used:
+            return None
+        return obj.duration_days
+
+    async def mark_token_as_used(self, token: str) -> None:
+        obj = await self.session.get(Token, token)
+        if obj:
+            obj.used = True
+            await self.session.commit()

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -7,8 +7,8 @@ def is_admin(user_id: int) -> bool:
     return user_id in ADMIN_IDS
 
 
-async def is_vip(bot: Bot, user_id: int) -> bool:
-    """Check if the user is subscribed to the VIP channel."""
+async def is_vip_member(bot: Bot, user_id: int) -> bool:
+    """Return True if the user currently belongs to the VIP channel."""
     if not VIP_CHANNEL_ID:
         return False
     try:
@@ -16,3 +16,8 @@ async def is_vip(bot: Bot, user_id: int) -> bool:
         return member.status in {"member", "administrator", "creator"}
     except Exception:
         return False
+
+
+async def is_vip(bot: Bot, user_id: int) -> bool:
+    """Backward compatible alias for :func:`is_vip_member`."""
+    return await is_vip_member(bot, user_id)


### PR DESCRIPTION
## Summary
- branch menu by admin vs VIP vs free user
- show VIP menu with subscription button
- add admin VIP menu with subscription tools
- add subscription, token and config services
- extend database models for subscriptions

## Testing
- `python -m py_compile mybot/handlers/start.py mybot/handlers/vip/menu.py mybot/handlers/admin/vip_menu.py mybot/keyboards/vip_kb.py mybot/keyboards/admin_vip_kb.py mybot/utils/user_roles.py mybot/services/*.py mybot/database/models.py`

------
https://chatgpt.com/codex/tasks/task_e_684e6e2d43d08329ac1d9c15717e396a