### PR TITLE
Add VIP_IDS env var for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
    export BOT_TOKEN="<your_bot_token>"
    export ADMIN_IDS="11111;22222"       # user IDs with admin privileges
    export VIP_CHANNEL_ID="-100123456789"  # ID of the VIP Telegram channel
+   export VIP_IDS=""                   # optional semicolon-separated list of user IDs treated as VIP
    ```
 
 3. Run the bot:

--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -13,11 +13,19 @@ if BOT_TOKEN == "YOUR_BOT_TOKEN" or not BOT_TOKEN:
         "BOT_TOKEN environment variable is not set or contains the default placeholder."
     )
 
-# Telegram user IDs of admins provided as a comma separated list in
-# the ``ADMIN_IDS`` environment variable. Falling back to an empty
-# list keeps the bot running even if no admins are configured.
+# Telegram user IDs of admins provided as a semicolon separated list in
+# the ``ADMIN_IDS`` environment variable. Falling back to an empty list
+# keeps the bot running even if no admins are configured.
 ADMIN_IDS: List[int] = [
     int(uid) for uid in os.environ.get("ADMIN_IDS", "").split(";") if uid.strip()
+]
+
+# Optional list of VIP user IDs for testing purposes. Values are taken
+# from the ``VIP_IDS`` environment variable as a semicolon separated
+# list. When a user ID appears here it will be treated as a VIP even if
+# they are not part of the configured VIP channel.
+VIP_IDS: List[int] = [
+    int(uid) for uid in os.environ.get("VIP_IDS", "").split(";") if uid.strip()
 ]
 
 # Identifier of the VIP channel where subscribers are checked. This

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -1,5 +1,5 @@
 from aiogram import Bot
-from .config import ADMIN_IDS, VIP_CHANNEL_ID
+from .config import ADMIN_IDS, VIP_CHANNEL_ID, VIP_IDS
 
 
 def is_admin(user_id: int) -> bool:
@@ -9,6 +9,8 @@ def is_admin(user_id: int) -> bool:
 
 async def is_vip_member(bot: Bot, user_id: int) -> bool:
     """Return True if the user currently belongs to the VIP channel."""
+    if user_id in VIP_IDS:
+        return True
     if not VIP_CHANNEL_ID:
         return False
     try:


### PR DESCRIPTION
## Summary
- add `VIP_IDS` configuration list
- treat `VIP_IDS` as VIP users
- document `VIP_IDS` env variable in README

## Testing
- `python -m py_compile mybot/utils/config.py mybot/utils/user_roles.py`

------
https://chatgpt.com/codex/tasks/task_e_684e727fd5e48329a2565c5d6cc0990d