### PR TITLE
Improve Juego del Diván navigation and profile

### DIFF
--- a/mybot/handlers/vip/game_menu.py
+++ b/mybot/handlers/vip/game_menu.py
@@ -1,0 +1,39 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import User
+from services.mission_service import MissionService
+from utils.message_utils import get_profile_message
+from keyboards.vip_game_kb import get_game_menu_kb, get_profile_kb
+from utils.navigation import return_to_parent_menu
+
+router = Router()
+
+@router.callback_query(F.data == "game_menu")
+async def show_game_menu(callback: CallbackQuery):
+    await callback.message.edit_text(
+        "Elige una opción:",
+        reply_markup=get_game_menu_kb(include_back=True),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "game_profile")
+async def show_game_profile(callback: CallbackQuery, session: AsyncSession):
+    user_id = callback.from_user.id
+    user = await session.get(User, user_id)
+    if not user:
+        await callback.answer("Debes iniciar con /start", show_alert=True)
+        return
+    mission_service = MissionService(session)
+    active_missions = await mission_service.get_active_missions(user_id=user_id)
+    text = await get_profile_message(user, active_missions)
+    await callback.message.edit_text(text, reply_markup=get_profile_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "game_back")
+async def handle_game_back(callback: CallbackQuery):
+    await return_to_parent_menu(callback.message, callback.bot, callback.from_user.id)
+    await callback.answer()

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -5,10 +5,12 @@ from aiogram.filters import Command
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from keyboards.vip_kb import get_vip_kb
+from .game_menu import router as game_router
 from utils.user_roles import is_vip_member
 from services.subscription_service import SubscriptionService
 
 router = Router()
+router.include_router(game_router)
 
 
 @router.message(Command("vip_menu"))

--- a/mybot/keyboards/admin_main_kb.py
+++ b/mybot/keyboards/admin_main_kb.py
@@ -8,6 +8,5 @@ def get_admin_main_kb():
     builder.button(text="💬 Canal Free", callback_data="admin_free")
     builder.button(text="🎮 Juego Kinky", callback_data="admin_game")
     builder.button(text="🛠 Configuración del Bot", callback_data="admin_config")
-    builder.button(text="🔙 Volver", callback_data="admin_back")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/keyboards/vip_game_kb.py
+++ b/mybot/keyboards/vip_game_kb.py
@@ -1,8 +1,20 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
-def get_game_menu_kb():
+def get_game_menu_kb(include_back: bool = False):
+    """Keyboard for the Juego del Diván main menu."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="Mi perfil", callback_data="game_profile")
+    builder.button(text="👤 Perfil", callback_data="game_profile")
     builder.button(text="Ganar puntos", callback_data="gain_points")
+    if include_back:
+        builder.button(text="🔙 Volver", callback_data="game_back")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_profile_kb():
+    """Keyboard for the profile screen inside the game."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🔙 Volver", callback_data="game_menu")
+    builder.adjust(1)
     return builder.as_markup()

--- a/mybot/keyboards/vip_kb.py
+++ b/mybot/keyboards/vip_kb.py
@@ -6,6 +6,6 @@ def get_vip_kb():
 
     builder = InlineKeyboardBuilder()
     builder.button(text="🧾 Mi Suscripción", callback_data="vip_subscription")
-    builder.button(text="🎮 Juego del Diván", callback_data="menu_principal")
+    builder.button(text="🎮 Juego del Diván", callback_data="game_menu")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/utils/navigation.py
+++ b/mybot/utils/navigation.py
@@ -1,0 +1,23 @@
+from aiogram.types import Message
+from keyboards.admin_main_kb import get_admin_main_kb
+from keyboards.vip_kb import get_vip_kb
+from keyboards.subscription_kb import get_subscription_kb
+from utils.user_roles import is_admin, is_vip_member
+
+async def return_to_parent_menu(message: Message, bot, user_id: int) -> None:
+    """Return to the parent menu based on the user's role."""
+    if is_admin(user_id):
+        await message.edit_text(
+            "Menú de administración",
+            reply_markup=get_admin_main_kb(),
+        )
+    elif await is_vip_member(bot, user_id):
+        await message.edit_text(
+            "Menú para suscriptores VIP",
+            reply_markup=get_vip_kb(),
+        )
+    else:
+        await message.edit_text(
+            "Para acceder al canal VIP necesitas una suscripción.",
+            reply_markup=get_subscription_kb(),
+        )


### PR DESCRIPTION
## Summary
- hook VIP game menu callback to show profile and add back navigation
- add helper for returning to the appropriate parent menu
- remove back button from admin main menu
- include game router in VIP handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e7cbcdc7883298b6533d2ac38e337