### PR TITLE
Fix VIP admin features and profile

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -7,6 +7,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from database.setup import init_db, get_session
 
 from handlers import start, free_user
+from handlers.user import start_token
 from handlers.vip import menu as vip
 from handlers.admin import admin_router
 from utils.config import BOT_TOKEN
@@ -30,6 +31,7 @@ async def main() -> None:
     dp.message.outer_middleware(session_middleware_factory(Session, bot))
     dp.callback_query.outer_middleware(session_middleware_factory(Session, bot))
 
+    dp.include_router(start_token.router)
     dp.include_router(start.router)
     dp.include_router(admin_router)
     dp.include_router(vip.router)

--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -1,5 +1,5 @@
 # database/models.py
-from sqlalchemy import Column, Integer, String, BigInteger, DateTime, Boolean, JSON, Text
+from sqlalchemy import Column, Integer, String, BigInteger, DateTime, Boolean, JSON, Text, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
 from sqlalchemy.ext.asyncio import AsyncAttrs
@@ -77,6 +77,17 @@ class Subscription(AsyncAttrs, Base):
     end_date = Column(DateTime, nullable=False)
 
 
+class SubscriptionPlan(AsyncAttrs, Base):
+    """Available subscription plans."""
+
+    __tablename__ = "subscription_plans"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    duration_days = Column(Integer, nullable=False)
+    name = Column(String, nullable=False)
+    price = Column(Integer, nullable=False)
+
+
 class Token(AsyncAttrs, Base):
     """Invitation tokens used to activate a subscription plan."""
 
@@ -86,6 +97,7 @@ class Token(AsyncAttrs, Base):
     duration_days = Column(Integer, nullable=False)
     name = Column(String, nullable=False)
     price = Column(Integer, nullable=False)
+    plan_id = Column(Integer, ForeignKey("subscription_plans.id"), nullable=True)
     status = Column(String, default="available")
 
 

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -2,12 +2,12 @@ from .admin_menu import router as admin_router
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
-from .subscriptions import router as subscriptions_router
+from .subscription_plans import router as subscription_plans_router
 
 __all__ = [
     "admin_router",
     "vip_router",
     "free_router",
     "config_router",
-    "subscriptions_router",
+    "subscription_plans_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -10,7 +10,7 @@ from utils.messages import BOT_MESSAGES
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
-from .subscriptions import router as sub_router
+from .subscription_plans import router as sub_router
 from handlers.vip.gamification import router as game_router
 
 router = Router()

--- a/mybot/handlers/admin/subscription_plans.py
+++ b/mybot/handlers/admin/subscription_plans.py
@@ -47,6 +47,7 @@ async def plan_name_input(message: Message):
     data = _waiting_name.pop(message.from_user.id)
     data["name"] = message.text.strip()
     _waiting_price[message.from_user.id] = data
+    await message.delete()
     await message.answer("Ingresa el precio del plan")
 
 
@@ -56,12 +57,15 @@ async def plan_price_input(message: Message, session: AsyncSession):
     try:
         price = int(message.text.strip())
     except ValueError:
+        await message.delete()
         await message.answer("Ingresa solo números para el precio")
         return
     service = TokenService(session)
-    plan = await service.create_plan(data["duration"], data["name"], price)
-    bot_username = (await message.bot.me()).username
-    link = f"https://t.me/{bot_username}?start={plan.token}"
-    await message.answer(f"Plan creado: {plan.name} - {plan.price}\nEnlace: {link}")
+    await service.add_subscription_plan(data["duration"], data["name"], price)
+    await message.delete()
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🔙 Volver", callback_data="config_plans")
+    builder.adjust(1)
+    await message.answer("✅ Plan creado correctamente.", reply_markup=builder.as_markup())
 
 

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -7,28 +7,18 @@ from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_kb import get_vip_kb
 from keyboards.subscription_kb import get_subscription_kb
 from utils.user_roles import is_admin, is_vip_member
-from services import TokenService, SubscriptionService
-from utils.telegram_links import create_invite_link
+from services import SubscriptionService
 
 router = Router()
 
 
-@router.message(CommandStart(deep_link=True))
+@router.message(CommandStart())
 async def cmd_start(message: Message, session: AsyncSession):
-    user_id = message.from_user.id
     args = message.get_args()
     if args:
-        service = TokenService(session)
-        plan = await service.validate_token(args)
-        if plan:
-            sub_service = SubscriptionService(session)
-            await sub_service.add_subscription(user_id, plan.duration_days)
-            await service.mark_token_as_used(args)
-            link = await create_invite_link(message.bot)
-            await message.answer(
-                f"Suscripción {plan.name} activada. Aquí tienes tu enlace: {link}"
-            )
-            return
+        # Token handling is managed in handlers.user.start_token
+        return
+    user_id = message.from_user.id
 
     if is_admin(user_id):
         await message.answer(

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -1,0 +1,26 @@
+from aiogram import Router
+from aiogram.filters import CommandStart
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services import TokenService, SubscriptionService
+from utils.telegram_links import create_invite_link
+
+router = Router()
+
+@router.message(CommandStart(deep_link=True))
+async def start_with_token(message: Message, session: AsyncSession):
+    args = message.get_args()
+    if not args:
+        return
+    service = TokenService(session)
+    plan = await service.validate_token(args)
+    if not plan:
+        return
+    sub_service = SubscriptionService(session)
+    await sub_service.add_subscription(message.from_user.id, plan.duration_days)
+    await service.mark_token_as_used(args)
+    link = await create_invite_link(message.bot)
+    await message.answer(
+        f"Suscripción {plan.name} activada. Aquí tienes tu enlace: {link}"
+    )


### PR DESCRIPTION
## Summary
- rename `subscriptions.py` to `subscription_plans.py` and support plan creation without link
- adjust admin VIP header text
- show VIP status in game profile
- clean admin input messages and provide back buttons
- generate invite links from subscription plans
- create `/start <token>` handler and update bot entry
- support subscription plan storage in DB and token service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8dab45c08329bb719be4727e5e70