### PR TITLE
Implement VIP role menus and admin management

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -67,6 +67,30 @@ class Event(AsyncAttrs, Base):
     created_at = Column(DateTime, default=func.now())
 
 
+class VipSubscription(AsyncAttrs, Base):
+    __tablename__ = "vip_subscriptions"
+    user_id = Column(BigInteger, primary_key=True)
+    expires_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=func.now())
+
+
+class InviteToken(AsyncAttrs, Base):
+    __tablename__ = "invite_tokens"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    token = Column(String, unique=True, nullable=False)
+    created_by = Column(BigInteger, nullable=False)
+    used_by = Column(BigInteger, nullable=True)
+    created_at = Column(DateTime, default=func.now())
+    used_at = Column(DateTime, nullable=True)
+    expires_at = Column(DateTime, nullable=True)
+
+
+class ConfigEntry(AsyncAttrs, Base):
+    __tablename__ = "config_entries"
+    key = Column(String, primary_key=True)
+    value = Column(String, nullable=True)
+
+
 # Funciones para manejar el estado del menú del usuario
 async def get_user_menu_state(session, user_id: int) -> str:
     result = await session.execute(select(User).where(User.id == user_id))

--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -1,14 +1,67 @@
 from aiogram import Router, F
 from aiogram.types import CallbackQuery
-from utils.user_roles import is_admin
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.user_roles import is_admin, is_vip_member
+from keyboards.admin_vip_kb import get_admin_vip_kb
+from keyboards.vip_kb import get_vip_kb
+from services import TokenService, SubscriptionService, ConfigService
 
 router = Router()
 
 
 @router.callback_query(F.data == "admin_vip")
 async def vip_menu(callback: CallbackQuery):
-    """Placeholder VIP admin menu."""
     if not is_admin(callback.from_user.id):
         return await callback.answer()
-    await callback.message.edit_text("Secci\u00f3n VIP en construcci\u00f3n")
+    await callback.message.edit_text(
+        "Administración del VIP", reply_markup=get_admin_vip_kb()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_invite")
+async def create_invite(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    token_service = TokenService(session)
+    token = await token_service.create_token(callback.from_user.id)
+    await callback.message.edit_text(
+        f"Invitación generada: {token.token}", reply_markup=get_admin_vip_kb()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_manage")
+async def manage_subs(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    result = await session.execute("SELECT COUNT(*) FROM vip_subscriptions")
+    count = result.scalar() or 0
+    await callback.message.edit_text(
+        f"Suscriptores activos: {count}", reply_markup=get_admin_vip_kb()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_config")
+async def vip_config(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    config = ConfigService(session)
+    price = await config.get_value("vip_price")
+    price_text = price or "No establecido"
+    await callback.message.edit_text(
+        f"Precio actual del VIP: {price_text}", reply_markup=get_admin_vip_kb()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_game")
+async def vip_game(callback: CallbackQuery):
+    if not await is_vip_member(callback.bot, callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Accede al Juego del Diván", reply_markup=get_vip_kb()
+    )
     await callback.answer()

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -5,7 +5,7 @@ from aiogram.types import Message
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_kb import get_vip_kb
 from keyboards.subscription_kb import get_subscription_kb
-from utils.user_roles import is_admin, is_vip
+from utils.user_roles import is_admin, is_vip_member
 
 router = Router()
 
@@ -18,7 +18,7 @@ async def cmd_start(message: Message):
             "Bienvenido, administrador!",
             reply_markup=get_admin_main_kb(),
         )
-    elif await is_vip(message.bot, user_id):
+    elif await is_vip_member(message.bot, user_id):
         await message.answer(
             "Bienvenido, suscriptor VIP!",
             reply_markup=get_vip_kb(),

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -1,20 +1,34 @@
 from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
 from aiogram.filters import Command
 
 from keyboards.vip_kb import get_vip_kb
-from utils.user_roles import is_vip
+from utils.user_roles import is_vip_member
+from services.subscription_service import SubscriptionService
 
 router = Router()
 
 
 @router.message(Command("vip_menu"))
-async def vip_menu(message: Message):
-    if not await is_vip(message.bot, message.from_user.id):
+async def vip_menu(message: Message, session: AsyncSession):
+    if not await is_vip_member(message.bot, message.from_user.id):
         return
-    await message.answer("Menú para suscriptores VIP", reply_markup=get_vip_kb())
+    sub_service = SubscriptionService(session)
+    sub = await sub_service.get_subscription(message.from_user.id)
+    status = "Activa" if sub else "Sin registro"
+    await message.answer(
+        f"Suscripción VIP: {status}", reply_markup=get_vip_kb()
+    )
 
 
-@router.callback_query(F.data == "vip_button")
-async def vip_placeholder_handler(callback: CallbackQuery):
-    await callback.answer("Acción de suscriptor VIP")
+@router.callback_query(F.data == "vip_subscription")
+async def vip_subscription(callback: CallbackQuery, session: AsyncSession):
+    if not await is_vip_member(callback.bot, callback.from_user.id):
+        return await callback.answer()
+    sub_service = SubscriptionService(session)
+    sub = await sub_service.get_subscription(callback.from_user.id)
+    text = "No registrada" if not sub else f"Válida hasta {sub.expires_at}"
+    await callback.message.edit_text(text, reply_markup=get_vip_kb())
+    await callback.answer()
+

--- a/mybot/keyboards/admin_vip_kb.py
+++ b/mybot/keyboards/admin_vip_kb.py
@@ -1,0 +1,12 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_vip_kb() -> InlineKeyboardBuilder:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📊 Estadísticas", callback_data="vip_stats")
+    builder.button(text="🔗 Crear Invitación", callback_data="vip_invite")
+    builder.button(text="👥 Suscriptores", callback_data="vip_manage")
+    builder.button(text="⚙️ Configuración", callback_data="vip_config")
+    builder.button(text="🔙 Volver", callback_data="admin_back")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/vip_kb.py
+++ b/mybot/keyboards/vip_kb.py
@@ -2,9 +2,10 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
 def get_vip_kb():
-    """Return a minimal VIP subscriber menu."""
+    """Keyboard for regular VIP users."""
 
     builder = InlineKeyboardBuilder()
-    # Single button for VIP subscribers
-    builder.button(text="Botón de suscriptor VIP", callback_data="vip_button")
+    builder.button(text="🧾 Mi Suscripción", callback_data="vip_subscription")
+    builder.button(text="🎮 Juego del Diván", callback_data="vip_game")
+    builder.adjust(1)
     return builder.as_markup()

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -1,0 +1,19 @@
+from .achievement_service import AchievementService
+from .level_service import LevelService
+from .mission_service import MissionService
+from .point_service import PointService
+from .reward_service import RewardService
+from .subscription_service import SubscriptionService
+from .token_service import TokenService
+from .config_service import ConfigService
+
+__all__ = [
+    "AchievementService",
+    "LevelService",
+    "MissionService",
+    "PointService",
+    "RewardService",
+    "SubscriptionService",
+    "TokenService",
+    "ConfigService",
+]

--- a/mybot/services/config_service.py
+++ b/mybot/services/config_service.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import ConfigEntry
+
+
+class ConfigService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_value(self, key: str) -> str | None:
+        entry = await self.session.get(ConfigEntry, key)
+        return entry.value if entry else None
+
+    async def set_value(self, key: str, value: str) -> ConfigEntry:
+        entry = await self.session.get(ConfigEntry, key)
+        if entry:
+            entry.value = value
+        else:
+            entry = ConfigEntry(key=key, value=value)
+            self.session.add(entry)
+        await self.session.commit()
+        await self.session.refresh(entry)
+        return entry
+

--- a/mybot/services/subscription_service.py
+++ b/mybot/services/subscription_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from database.models import VipSubscription
+
+
+class SubscriptionService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_subscription(self, user_id: int) -> VipSubscription | None:
+        stmt = select(VipSubscription).where(VipSubscription.user_id == user_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create_subscription(self, user_id: int, expires_at: datetime | None = None) -> VipSubscription:
+        sub = VipSubscription(user_id=user_id, expires_at=expires_at)
+        self.session.add(sub)
+        await self.session.commit()
+        await self.session.refresh(sub)
+        return sub
+

--- a/mybot/services/token_service.py
+++ b/mybot/services/token_service.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from secrets import token_urlsafe
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from database.models import InviteToken
+
+
+class TokenService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create_token(self, created_by: int, expires_in: int | None = None) -> InviteToken:
+        token = token_urlsafe(16)
+        expires_at = datetime.utcnow() + timedelta(seconds=expires_in) if expires_in else None
+        obj = InviteToken(token=token, created_by=created_by, expires_at=expires_at)
+        self.session.add(obj)
+        await self.session.commit()
+        await self.session.refresh(obj)
+        return obj
+
+    async def use_token(self, token: str, user_id: int) -> bool:
+        stmt = select(InviteToken).where(InviteToken.token == token)
+        result = await self.session.execute(stmt)
+        obj = result.scalar_one_or_none()
+        if not obj or obj.used_by or (obj.expires_at and obj.expires_at < datetime.utcnow()):
+            return False
+        obj.used_by = user_id
+        obj.used_at = datetime.utcnow()
+        await self.session.commit()
+        return True
+

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -7,8 +7,8 @@ def is_admin(user_id: int) -> bool:
     return user_id in ADMIN_IDS
 
 
-async def is_vip(bot: Bot, user_id: int) -> bool:
-    """Check if the user is subscribed to the VIP channel."""
+async def is_vip_member(bot: Bot, user_id: int) -> bool:
+    """Check if the user currently belongs to the VIP channel."""
     if not VIP_CHANNEL_ID:
         return False
     try:
@@ -16,3 +16,7 @@ async def is_vip(bot: Bot, user_id: int) -> bool:
         return member.status in {"member", "administrator", "creator"}
     except Exception:
         return False
+
+
+# Backwards compatibility
+is_vip = is_vip_member


### PR DESCRIPTION
## Summary
- add tables for VIP subscriptions, invite tokens and bot config
- create services for subscription, token and configuration management
- show VIP keyboard with subscription and game options
- implement admin Canal VIP menu with invite and stats tools
- route `/start` through new VIP membership check

## Testing
- `python -m py_compile mybot/handlers/start.py mybot/handlers/vip/menu.py mybot/handlers/admin/vip_menu.py mybot/keyboards/vip_kb.py mybot/keyboards/admin_vip_kb.py mybot/utils/user_roles.py mybot/services/*.py mybot/database/models.py`

------
https://chatgpt.com/codex/tasks/task_e_684eaa68a5cc8329932f98bdfd29069f