### PR TITLE
Add VIP user list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
    export BOT_TOKEN="<your_bot_token>"
    export ADMIN_IDS="11111;22222"       # user IDs with admin privileges
    export VIP_CHANNEL_ID="-100123456789"  # ID of the VIP Telegram channel
+   export VIP_IDS="33333;44444"        # optional list of VIP user IDs
    ```
 
 3. Run the bot:

--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -13,11 +13,19 @@ if BOT_TOKEN == "YOUR_BOT_TOKEN" or not BOT_TOKEN:
         "BOT_TOKEN environment variable is not set or contains the default placeholder."
     )
 
-# Telegram user IDs of admins provided as a comma separated list in
+# Telegram user IDs of admins provided as a semicolon separated list in
 # the ``ADMIN_IDS`` environment variable. Falling back to an empty
 # list keeps the bot running even if no admins are configured.
 ADMIN_IDS: List[int] = [
     int(uid) for uid in os.environ.get("ADMIN_IDS", "").split(";") if uid.strip()
+]
+
+# Telegram user IDs with a VIP subscription. This is helpful for
+# testing without relying on channel membership. The IDs should be
+# provided through the ``VIP_IDS`` environment variable separated by
+# semicolons.
+VIP_IDS: List[int] = [
+    int(uid) for uid in os.environ.get("VIP_IDS", "").split(";") if uid.strip()
 ]
 
 # Identifier of the VIP channel where subscribers are checked. This
@@ -29,4 +37,5 @@ class Config:
     BOT_TOKEN = BOT_TOKEN
     ADMIN_ID = ADMIN_IDS[0] if ADMIN_IDS else 0
     CHANNEL_ID = VIP_CHANNEL_ID
+    VIP_IDS = VIP_IDS
     DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///gamification.db")

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -1,5 +1,5 @@
 from aiogram import Bot
-from .config import ADMIN_IDS, VIP_CHANNEL_ID
+from .config import ADMIN_IDS, VIP_IDS, VIP_CHANNEL_ID
 
 
 def is_admin(user_id: int) -> bool:
@@ -8,7 +8,9 @@ def is_admin(user_id: int) -> bool:
 
 
 async def is_vip_member(bot: Bot, user_id: int) -> bool:
-    """Check if the user currently belongs to the VIP channel."""
+    """Check if the user currently belongs to the VIP channel or list."""
+    if user_id in VIP_IDS:
+        return True
     if not VIP_CHANNEL_ID:
         return False
     try:


### PR DESCRIPTION
## Summary
- read `VIP_IDS` env var for manually specified VIP users
- include the new setting in the configuration docs
- consider VIP_IDS when checking VIP membership

## Testing
- `python -m flake8 mybot`
- `python -m flake8 old_gamificacion`

------
https://chatgpt.com/codex/tasks/task_e_684ead5570cc83298c17d3ab4af05f54