### PR TITLE
Implement subscription plan creation flow

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -85,6 +85,20 @@ class InviteToken(AsyncAttrs, Base):
     expires_at = Column(DateTime, nullable=True)
 
 
+class SubscriptionPlan(AsyncAttrs, Base):
+    __tablename__ = "subscription_plans"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    token = Column(String, unique=True, nullable=False)
+    name = Column(String, nullable=False)
+    price = Column(Integer, nullable=False)
+    duration_days = Column(Integer, nullable=False)
+    status = Column(String, default="available")
+    created_by = Column(BigInteger, nullable=False)
+    used_by = Column(BigInteger, nullable=True)
+    created_at = Column(DateTime, default=func.now())
+    used_at = Column(DateTime, nullable=True)
+
+
 class ConfigEntry(AsyncAttrs, Base):
     __tablename__ = "config_entries"
     key = Column(String, primary_key=True)

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -2,10 +2,12 @@ from .admin_menu import router as admin_router
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
+from .tarifas_menu import router as tarifas_router
 
 __all__ = [
     "admin_router",
     "vip_router",
     "free_router",
     "config_router",
+    "tarifas_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -13,12 +13,14 @@ from database.models import get_user_menu_state
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
+from .tarifas_menu import router as tarifas_router
 from handlers.vip.gamification import router as game_router
 
 router = Router()
 router.include_router(vip_router)
 router.include_router(free_router)
 router.include_router(config_router)
+router.include_router(tarifas_router)
 router.include_router(game_router)
 
 

--- a/mybot/handlers/admin/config_menu.py
+++ b/mybot/handlers/admin/config_menu.py
@@ -3,7 +3,7 @@ from aiogram.types import CallbackQuery
 from sqlalchemy.ext.asyncio import AsyncSession
 from utils.user_roles import is_admin
 from utils.menu_utils import update_menu
-from keyboards.common import get_back_kb
+from keyboards.admin_config_kb import get_admin_config_kb
 
 router = Router()
 
@@ -15,8 +15,8 @@ async def config_menu(callback: CallbackQuery, session: AsyncSession):
         return await callback.answer()
     await update_menu(
         callback,
-        "Configuraci\u00f3n del bot en construcci\u00f3n",
-        get_back_kb(),
+        "Configuraci\u00f3n del bot",
+        get_admin_config_kb(),
         session,
         "admin_config",
     )

--- a/mybot/handlers/admin/tarifas_menu.py
+++ b/mybot/handlers/admin/tarifas_menu.py
@@ -1,0 +1,74 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import StatesGroup, State
+from aiogram import Bot
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.user_roles import is_admin
+from utils.menu_utils import update_menu
+from keyboards.tarifas_kb import get_tarifas_kb, get_duration_kb
+from services.plan_service import SubscriptionPlanService
+
+router = Router()
+
+
+class PlanStates(StatesGroup):
+    waiting_name = State()
+    waiting_price = State()
+
+
+@router.callback_query(F.data == "config_tarifas")
+async def tarifas_menu(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await update_menu(callback, "Gestión de Tarifas", get_tarifas_kb(), session, "config_tarifas")
+    await callback.answer()
+
+
+@router.callback_query(F.data == "tarifa_new")
+async def tarifa_new(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await update_menu(callback, "Selecciona la duración", get_duration_kb(), session, "config_tarifas_duration")
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("plan_dur_"))
+async def select_duration(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    duration = int(callback.data.split("_")[-1])
+    await state.update_data(duration_days=duration)
+    await callback.message.edit_text("Introduce el nombre de la tarifa:")
+    await state.set_state(PlanStates.waiting_name)
+    await callback.answer()
+
+
+@router.message(PlanStates.waiting_name)
+async def plan_name(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(name=message.text)
+    await message.answer("Introduce el precio:")
+    await state.set_state(PlanStates.waiting_price)
+
+
+@router.message(PlanStates.waiting_price)
+async def plan_price(message: Message, state: FSMContext, session: AsyncSession, bot: Bot):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    try:
+        price = int(message.text)
+    except ValueError:
+        await message.answer("Precio inválido. Ingresa un número.")
+        return
+    service = SubscriptionPlanService(session)
+    plan = await service.create_plan(message.from_user.id, data["name"], price, data["duration_days"])
+    bot_username = (await bot.get_me()).username
+    link = f"https://t.me/{bot_username}?start={plan.token}"
+    await message.answer(
+        f"Tarifa creada:\nNombre: {plan.name}\nPrecio: {plan.price}\nDuración: {plan.duration_days} días\nEnlace: {link}"
+    )
+    await state.clear()

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -1,24 +1,41 @@
-from aiogram import Router
+from aiogram import Router, Bot
 from aiogram.filters import CommandStart
 from aiogram.types import Message
+from datetime import datetime, timedelta
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_kb import get_vip_kb
 from keyboards.subscription_kb import get_subscription_kb
 from utils.user_roles import is_admin, is_vip_member
+from services import SubscriptionService, SubscriptionPlanService
 
 router = Router()
 
 
 @router.message(CommandStart())
-async def cmd_start(message: Message):
+async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
     user_id = message.from_user.id
+    args = message.text.split(maxsplit=1)
+    token = args[1] if len(args) > 1 else None
+
+    if token:
+        plan_service = SubscriptionPlanService(session)
+        sub_service = SubscriptionService(session)
+        plan = await plan_service.use_plan(token, user_id)
+        if plan:
+            expires_at = datetime.utcnow() + timedelta(days=plan.duration_days)
+            await sub_service.create_subscription(user_id, expires_at)
+            await message.answer("Suscripción activada correctamente!")
+        else:
+            await message.answer("Token inválido o ya utilizado.")
+
     if is_admin(user_id):
         await message.answer(
             "Bienvenido, administrador!",
             reply_markup=get_admin_main_kb(),
         )
-    elif await is_vip_member(message.bot, user_id):
+    elif await is_vip_member(bot, user_id):
         await message.answer(
             "Bienvenido, suscriptor VIP!",
             reply_markup=get_vip_kb(),

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -1,0 +1,9 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_config_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📄 Tarifas", callback_data="config_tarifas")
+    builder.button(text="🔙 Volver", callback_data="admin_back")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/tarifas_kb.py
+++ b/mybot/keyboards/tarifas_kb.py
@@ -1,0 +1,19 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_tarifas_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="➕ Nueva Tarifa", callback_data="tarifa_new")
+    builder.button(text="🔙 Volver", callback_data="admin_config")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_duration_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="1 D\u00eda", callback_data="plan_dur_1")
+    builder.button(text="1 Semana", callback_data="plan_dur_7")
+    builder.button(text="2 Semanas", callback_data="plan_dur_14")
+    builder.button(text="1 Mes", callback_data="plan_dur_30")
+    builder.adjust(2)
+    return builder.as_markup()

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -6,6 +6,7 @@ from .reward_service import RewardService
 from .subscription_service import SubscriptionService
 from .token_service import TokenService
 from .config_service import ConfigService
+from .plan_service import SubscriptionPlanService
 
 __all__ = [
     "AchievementService",
@@ -16,4 +17,5 @@ __all__ = [
     "SubscriptionService",
     "TokenService",
     "ConfigService",
+    "SubscriptionPlanService",
 ]

--- a/mybot/services/plan_service.py
+++ b/mybot/services/plan_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime
+from secrets import token_urlsafe
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from database.models import SubscriptionPlan
+
+
+class SubscriptionPlanService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create_plan(self, created_by: int, name: str, price: int, duration_days: int) -> SubscriptionPlan:
+        token = token_urlsafe(8)
+        plan = SubscriptionPlan(
+            token=token,
+            name=name,
+            price=price,
+            duration_days=duration_days,
+            created_by=created_by,
+            status="available",
+        )
+        self.session.add(plan)
+        await self.session.commit()
+        await self.session.refresh(plan)
+        return plan
+
+    async def get_plan(self, token: str) -> SubscriptionPlan | None:
+        stmt = select(SubscriptionPlan).where(SubscriptionPlan.token == token)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def use_plan(self, token: str, user_id: int) -> SubscriptionPlan | None:
+        plan = await self.get_plan(token)
+        if not plan or plan.status != "available":
+            return None
+        plan.status = "used"
+        plan.used_by = user_id
+        plan.used_at = datetime.utcnow()
+        await self.session.commit()
+        return plan


### PR DESCRIPTION
## Summary
- add database model for subscription plan tokens
- introduce service to manage plan creation and redemption
- enable admins to manage subscription plans via new Tarifa menu
- generate invite links for new plans
- support plan token handling in `/start`

## Testing
- `python -m compileall -q mybot`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684eb440e00483299fce05c13f28e3d9