### PR TITLE
Implement plan token generation

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -7,6 +7,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from database.setup import init_db, get_session
 
 from handlers import start, free_user
+from handlers.user import start_token
 from handlers.vip import menu as vip
 from handlers.admin import admin_router
 from utils.config import BOT_TOKEN
@@ -30,6 +31,7 @@ async def main() -> None:
     dp.message.outer_middleware(session_middleware_factory(Session, bot))
     dp.callback_query.outer_middleware(session_middleware_factory(Session, bot))
 
+    dp.include_router(start_token.router)
     dp.include_router(start.router)
     dp.include_router(admin_router)
     dp.include_router(vip.router)

--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -88,11 +88,22 @@ class InviteToken(AsyncAttrs, Base):
 class SubscriptionPlan(AsyncAttrs, Base):
     __tablename__ = "subscription_plans"
     id = Column(Integer, primary_key=True, autoincrement=True)
-    token = Column(String, unique=True, nullable=False)
+    token = Column(String, unique=True, nullable=True)
     name = Column(String, nullable=False)
     price = Column(Integer, nullable=False)
     duration_days = Column(Integer, nullable=False)
     status = Column(String, default="available")
+    created_by = Column(BigInteger, nullable=False)
+    used_by = Column(BigInteger, nullable=True)
+    created_at = Column(DateTime, default=func.now())
+    used_at = Column(DateTime, nullable=True)
+
+
+class SubscriptionToken(AsyncAttrs, Base):
+    __tablename__ = "subscription_tokens"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    token = Column(String, unique=True, nullable=False)
+    plan_id = Column(Integer, nullable=False)
     created_by = Column(BigInteger, nullable=False)
     used_by = Column(BigInteger, nullable=True)
     created_at = Column(DateTime, default=func.now())

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -2,12 +2,12 @@ from .admin_menu import router as admin_router
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
-from .tarifas_menu import router as tarifas_router
+from .subscription_plans import router as subscription_plans_router
 
 __all__ = [
     "admin_router",
     "vip_router",
     "free_router",
     "config_router",
-    "tarifas_router",
+    "subscription_plans_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -13,14 +13,14 @@ from database.models import get_user_menu_state
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
-from .tarifas_menu import router as tarifas_router
+from .subscription_plans import router as subscription_plans_router
 from handlers.vip.gamification import router as game_router
 
 router = Router()
 router.include_router(vip_router)
 router.include_router(free_router)
 router.include_router(config_router)
-router.include_router(tarifas_router)
+router.include_router(subscription_plans_router)
 router.include_router(game_router)
 
 

--- a/mybot/handlers/admin/subscription_plans.py
+++ b/mybot/handlers/admin/subscription_plans.py
@@ -66,9 +66,7 @@ async def plan_price(message: Message, state: FSMContext, session: AsyncSession,
         return
     service = SubscriptionPlanService(session)
     plan = await service.create_plan(message.from_user.id, data["name"], price, data["duration_days"])
-    bot_username = (await bot.get_me()).username
-    link = f"https://t.me/{bot_username}?start={plan.token}"
     await message.answer(
-        f"Tarifa creada:\nNombre: {plan.name}\nPrecio: {plan.price}\nDuración: {plan.duration_days} días\nEnlace: {link}"
+        f"Tarifa creada:\nNombre: {plan.name}\nPrecio: {plan.price}\nDuración: {plan.duration_days} días"
     )
     await state.clear()

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -1,14 +1,13 @@
 from aiogram import Router, Bot
 from aiogram.filters import CommandStart
 from aiogram.types import Message
-from datetime import datetime, timedelta
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from keyboards.admin_main_kb import get_admin_main_kb
-from keyboards.vip_kb import get_vip_kb
 from keyboards.subscription_kb import get_subscription_kb
 from utils.user_roles import is_admin, is_vip_member
-from services import SubscriptionService, SubscriptionPlanService
+from utils.keyboard_utils import get_main_menu_keyboard
+from utils.messages import BOT_MESSAGES
 
 router = Router()
 
@@ -16,19 +15,6 @@ router = Router()
 @router.message(CommandStart())
 async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
     user_id = message.from_user.id
-    args = message.text.split(maxsplit=1)
-    token = args[1] if len(args) > 1 else None
-
-    if token:
-        plan_service = SubscriptionPlanService(session)
-        sub_service = SubscriptionService(session)
-        plan = await plan_service.use_plan(token, user_id)
-        if plan:
-            expires_at = datetime.utcnow() + timedelta(days=plan.duration_days)
-            await sub_service.create_subscription(user_id, expires_at)
-            await message.answer("Suscripción activada correctamente!")
-        else:
-            await message.answer("Token inválido o ya utilizado.")
 
     if is_admin(user_id):
         await message.answer(
@@ -37,8 +23,8 @@ async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
         )
     elif await is_vip_member(bot, user_id):
         await message.answer(
-            "Bienvenido, suscriptor VIP!",
-            reply_markup=get_vip_kb(),
+            BOT_MESSAGES["start_welcome_returning_user"],
+            reply_markup=get_main_menu_keyboard(),
         )
     else:
         await message.answer(

--- a/mybot/handlers/user/__init__.py
+++ b/mybot/handlers/user/__init__.py
@@ -1,0 +1,3 @@
+from .start_token import router as start_token
+
+__all__ = ["start_token"]

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -1,0 +1,33 @@
+from aiogram import Router, Bot
+from aiogram.filters import CommandStart
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+from aiogram.filters.command import CommandObject
+from datetime import datetime, timedelta
+
+from services import SubscriptionService, SubscriptionPlanService, TokenService
+
+router = Router()
+
+
+@router.message(CommandStart(deep_link=True))
+async def start_with_token(message: Message, command: CommandObject, session: AsyncSession, bot: Bot):
+    token = command.args
+    if not token:
+        return
+    token_service = TokenService(session)
+    plan_token = await token_service.redeem_subscription_token(token, message.from_user.id)
+    if not plan_token:
+        await message.answer("Token inválido o ya utilizado.")
+        return
+
+    plan_service = SubscriptionPlanService(session)
+    plan = await plan_service.get_plan_by_id(plan_token.plan_id)
+    if not plan:
+        await message.answer("Plan no encontrado.")
+        return
+
+    sub_service = SubscriptionService(session)
+    expires_at = datetime.utcnow() + timedelta(days=plan.duration_days)
+    await sub_service.create_subscription(message.from_user.id, expires_at)
+    await message.answer("Suscripción activada correctamente!")

--- a/mybot/keyboards/admin_vip_kb.py
+++ b/mybot/keyboards/admin_vip_kb.py
@@ -5,6 +5,7 @@ def get_admin_vip_kb() -> InlineKeyboardBuilder:
     builder = InlineKeyboardBuilder()
     builder.button(text="📊 Estadísticas", callback_data="vip_stats")
     builder.button(text="🔗 Crear Invitación", callback_data="vip_invite")
+    builder.button(text="🔗 Generar Enlace", callback_data="vip_generate_link")
     builder.button(text="👥 Suscriptores", callback_data="vip_manage")
     builder.button(text="⚙️ Configuración", callback_data="vip_config")
     builder.button(text="🔙 Volver", callback_data="admin_back")

--- a/mybot/keyboards/tarifas_kb.py
+++ b/mybot/keyboards/tarifas_kb.py
@@ -17,3 +17,12 @@ def get_duration_kb():
     builder.button(text="1 Mes", callback_data="plan_dur_30")
     builder.adjust(2)
     return builder.as_markup()
+
+
+def get_plan_list_kb(plans):
+    builder = InlineKeyboardBuilder()
+    for plan in plans:
+        builder.button(text=plan.name, callback_data=f"plan_link_{plan.id}")
+    builder.button(text="🔙 Volver", callback_data="vip_generate_link_back")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/services/plan_service.py
+++ b/mybot/services/plan_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from secrets import token_urlsafe
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -13,9 +12,7 @@ class SubscriptionPlanService:
         self.session = session
 
     async def create_plan(self, created_by: int, name: str, price: int, duration_days: int) -> SubscriptionPlan:
-        token = token_urlsafe(8)
         plan = SubscriptionPlan(
-            token=token,
             name=name,
             price=price,
             duration_days=duration_days,
@@ -27,17 +24,10 @@ class SubscriptionPlanService:
         await self.session.refresh(plan)
         return plan
 
-    async def get_plan(self, token: str) -> SubscriptionPlan | None:
-        stmt = select(SubscriptionPlan).where(SubscriptionPlan.token == token)
-        result = await self.session.execute(stmt)
-        return result.scalar_one_or_none()
+    async def get_plan_by_id(self, plan_id: int) -> SubscriptionPlan | None:
+        return await self.session.get(SubscriptionPlan, plan_id)
 
-    async def use_plan(self, token: str, user_id: int) -> SubscriptionPlan | None:
-        plan = await self.get_plan(token)
-        if not plan or plan.status != "available":
-            return None
-        plan.status = "used"
-        plan.used_by = user_id
-        plan.used_at = datetime.utcnow()
-        await self.session.commit()
-        return plan
+    async def list_plans(self) -> list[SubscriptionPlan]:
+        result = await self.session.execute(select(SubscriptionPlan))
+        return result.scalars().all()
+


### PR DESCRIPTION
## Summary
- fix /start menu to show game buttons
- move tarifa handlers to subscription_plans
- add per-plan token flow
- support invite link creation for plans
- handle token redemption in a new handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684eba3059f8832988ac07b655a0b02e