### PR TITLE
Improve VIP admin navigation and stats

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -3,9 +3,11 @@ from aiogram.types import Message, CallbackQuery
 from aiogram.filters import CommandStart, Command
 
 from keyboards.admin_main_kb import get_admin_main_kb
+from keyboards.admin_vip_kb import get_admin_vip_kb
 from utils.user_roles import is_admin
 from utils.keyboard_utils import get_main_menu_keyboard, get_admin_main_keyboard
 from utils.messages import BOT_MESSAGES
+from utils.admin_state import reset_state, push_state, pop_state, current_state
 
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
@@ -23,14 +25,20 @@ router.include_router(game_router)
 async def admin_start(message: Message):
     if not is_admin(message.from_user.id):
         return
-    await message.answer("Men\u00fa de administraci\u00f3n", reply_markup=get_admin_main_kb())
+    reset_state(message.from_user.id)
+    await message.answer(
+        "Men\u00fa de administraci\u00f3n", reply_markup=get_admin_main_kb()
+    )
 
 
 @router.message(Command("admin_menu"))
 async def admin_menu(message: Message):
     if not is_admin(message.from_user.id):
         return
-    await message.answer("Men\u00fa de administraci\u00f3n", reply_markup=get_admin_main_kb())
+    reset_state(message.from_user.id)
+    await message.answer(
+        "Men\u00fa de administraci\u00f3n", reply_markup=get_admin_main_kb()
+    )
 
 
 @router.callback_query(F.data == "admin_game")
@@ -48,5 +56,14 @@ async def admin_game_entry(callback: CallbackQuery):
 async def admin_back(callback: CallbackQuery):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
-    await callback.message.delete()
+    state = pop_state(callback.from_user.id)
+
+    if state == "vip":
+        text = "Administración del VIP"
+        kb = get_admin_vip_kb()
+    else:
+        text = "Menú de administración"
+        kb = get_admin_main_kb()
+
+    await callback.message.edit_text(text, reply_markup=kb)
     await callback.answer()

--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -1,11 +1,14 @@
 from aiogram import Router, F
 from aiogram.types import CallbackQuery
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from utils.user_roles import is_admin, is_vip_member
 from keyboards.admin_vip_kb import get_admin_vip_kb
 from keyboards.vip_kb import get_vip_kb
 from services import TokenService, SubscriptionService, ConfigService
+from utils.admin_state import push_state
 
 router = Router()
 
@@ -14,6 +17,7 @@ router = Router()
 async def vip_menu(callback: CallbackQuery):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
+    push_state(callback.from_user.id, "vip")
     await callback.message.edit_text(
         "Administración del VIP", reply_markup=get_admin_vip_kb()
     )
@@ -32,15 +36,59 @@ async def create_invite(callback: CallbackQuery, session: AsyncSession):
     await callback.answer()
 
 
-@router.callback_query(F.data == "vip_manage")
-async def manage_subs(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "vip_stats")
+async def vip_stats(callback: CallbackQuery, session: AsyncSession):
+    """Show VIP subscription statistics."""
     if not is_admin(callback.from_user.id):
         return await callback.answer()
-    result = await session.execute("SELECT COUNT(*) FROM vip_subscriptions")
-    count = result.scalar() or 0
-    await callback.message.edit_text(
-        f"Suscriptores activos: {count}", reply_markup=get_admin_vip_kb()
+
+    push_state(callback.from_user.id, "vip_stats")
+    sub_service = SubscriptionService(session)
+    total, active, expired = await sub_service.get_statistics()
+
+    text = (
+        f"Suscripciones totales: {total}\n"
+        f"Activas: {active}\n"
+        f"Expiradas: {expired}"
     )
+    await callback.message.edit_text(text, reply_markup=get_admin_vip_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("vip_manage"))
+async def manage_subs(callback: CallbackQuery, session: AsyncSession):
+    """List active VIP subscribers with simple pagination."""
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+
+    # Extract page from callback data: vip_manage or vip_manage:1
+    parts = callback.data.split(":")
+    page = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
+
+    push_state(callback.from_user.id, "vip_manage")
+
+    sub_service = SubscriptionService(session)
+    subs = await sub_service.get_active_subscribers()
+    page_size = 10
+    start = page * page_size
+    current = subs[start : start + page_size]
+
+    lines = [f"{i+start+1}. {sub.user_id}" for i, sub in enumerate(current)]
+    text = (
+        "Suscriptores VIP activos:\n" + "\n".join(lines)
+        if lines
+        else "No hay suscriptores activos."
+    )
+
+    builder = InlineKeyboardBuilder()
+    if start > 0:
+        builder.button(text="⬅️", callback_data=f"vip_manage:{page - 1}")
+    if start + page_size < len(subs):
+        builder.button(text="➡️", callback_data=f"vip_manage:{page + 1}")
+    builder.button(text="🔙 Volver", callback_data="admin_back")
+    builder.adjust(2)
+
+    await callback.message.edit_text(text, reply_markup=builder.as_markup())
     await callback.answer()
 
 

--- a/mybot/services/subscription_service.py
+++ b/mybot/services/subscription_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func
 
 from database.models import VipSubscription
 
@@ -16,10 +16,52 @@ class SubscriptionService:
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def create_subscription(self, user_id: int, expires_at: datetime | None = None) -> VipSubscription:
+    async def create_subscription(
+        self, user_id: int, expires_at: datetime | None = None
+    ) -> VipSubscription:
         sub = VipSubscription(user_id=user_id, expires_at=expires_at)
         self.session.add(sub)
         await self.session.commit()
         await self.session.refresh(sub)
         return sub
 
+    async def get_statistics(self) -> tuple[int, int, int]:
+        """Return total, active and expired subscription counts."""
+        now = datetime.utcnow()
+
+        total_stmt = select(func.count()).select_from(VipSubscription)
+        active_stmt = (
+            select(func.count())
+            .select_from(VipSubscription)
+            .where(
+                (VipSubscription.expires_at.is_(None))
+                | (VipSubscription.expires_at > now)
+            )
+        )
+        expired_stmt = (
+            select(func.count())
+            .select_from(VipSubscription)
+            .where(
+                VipSubscription.expires_at.is_not(None),
+                VipSubscription.expires_at <= now,
+            )
+        )
+
+        total_res = await self.session.execute(total_stmt)
+        active_res = await self.session.execute(active_stmt)
+        expired_res = await self.session.execute(expired_stmt)
+
+        return (
+            total_res.scalar() or 0,
+            active_res.scalar() or 0,
+            expired_res.scalar() or 0,
+        )
+
+    async def get_active_subscribers(self) -> list[VipSubscription]:
+        """Return list of currently active subscriptions."""
+        now = datetime.utcnow()
+        stmt = select(VipSubscription).where(
+            (VipSubscription.expires_at.is_(None)) | (VipSubscription.expires_at > now)
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -1,0 +1,33 @@
+from collections import defaultdict
+from typing import Dict, List
+
+# Simple in-memory stack of admin menu states per user
+_user_states: Dict[int, List[str]] = defaultdict(list)
+
+
+def reset_state(user_id: int) -> None:
+    """Initialize the state stack for an admin user."""
+    _user_states[user_id] = ["main"]
+
+
+def push_state(user_id: int, state: str) -> None:
+    """Push a new state onto the user's stack if it isn't the current one."""
+    stack = _user_states.setdefault(user_id, ["main"])
+    if not stack or stack[-1] != state:
+        stack.append(state)
+
+
+def pop_state(user_id: int) -> str:
+    """Pop the current state and return the new one."""
+    stack = _user_states.get(user_id, ["main"])
+    if stack:
+        stack.pop()
+    if not stack:
+        stack.append("main")
+    return stack[-1]
+
+
+def current_state(user_id: int) -> str:
+    """Return the current state for the user."""
+    stack = _user_states.get(user_id, ["main"])
+    return stack[-1]


### PR DESCRIPTION
## Summary
- add simple admin menu state tracker
- connect VIP admin stats and subscriber list handlers
- improve admin back navigation so menus persist
- provide VIP stats and listing via SubscriptionService

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile mybot/utils/admin_state.py mybot/handlers/admin/admin_menu.py mybot/handlers/admin/vip_menu.py mybot/services/subscription_service.py`

------
https://chatgpt.com/codex/tasks/task_e_684eaedcb5008329b8dd2529c40c5aa0