### PR TITLE
Fix VIP admin header and restore game profile

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -21,7 +21,7 @@ async def vip_menu(callback: CallbackQuery, session: AsyncSession):
         return await callback.answer()
     await update_menu(
         callback,
-        "Administración del VIP",
+        "El Diván",
         get_admin_vip_kb(),
         session,
         "admin_vip",

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -3,9 +3,16 @@ from aiogram.types import Message, CallbackQuery
 from sqlalchemy.ext.asyncio import AsyncSession
 from aiogram.filters import Command
 
+from datetime import datetime
+
 from keyboards.vip_kb import get_vip_kb
+from keyboards.vip_game_kb import get_game_menu_kb
 from utils.user_roles import is_vip_member
+from utils.keyboard_utils import get_back_keyboard
+from utils.message_utils import get_profile_message
 from services.subscription_service import SubscriptionService
+from services.mission_service import MissionService
+from database.models import User
 
 router = Router()
 
@@ -30,5 +37,43 @@ async def vip_subscription(callback: CallbackQuery, session: AsyncSession):
     sub = await sub_service.get_subscription(callback.from_user.id)
     text = "No registrada" if not sub else f"Válida hasta {sub.expires_at}"
     await callback.message.edit_text(text, reply_markup=get_vip_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_game")
+async def vip_game(callback: CallbackQuery, session: AsyncSession):
+    if not await is_vip_member(callback.bot, callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Accede al Juego del Diván", reply_markup=get_game_menu_kb()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "game_profile")
+async def game_profile(callback: CallbackQuery, session: AsyncSession):
+    if not await is_vip_member(callback.bot, callback.from_user.id):
+        return await callback.answer()
+
+    user_id = callback.from_user.id
+    user: User | None = await session.get(User, user_id)
+    if not user:
+        return await callback.answer()
+
+    mission_service = MissionService(session)
+    active_missions = await mission_service.get_active_missions(user_id=user_id)
+
+    profile_message = await get_profile_message(user, active_missions)
+
+    sub_service = SubscriptionService(session)
+    sub = await sub_service.get_subscription(user_id)
+    is_active = sub and (sub.expires_at is None or sub.expires_at > datetime.utcnow())
+    vip_status = "Activo" if is_active else "Expirado"
+
+    profile_message += f"\n\nVIP: {vip_status}"
+
+    await callback.message.edit_text(
+        profile_message, reply_markup=get_back_keyboard("vip_game")
+    )
     await callback.answer()
 


### PR DESCRIPTION
## Summary
- adjust VIP admin menu header text
- show VIP game menu for regular VIP users
- implement profile screen for Juego del Diván

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684eb9b4f5e0832987fda3e8844b4b3b