### PR TITLE
Fix router import in main bot

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -31,7 +31,7 @@ async def main() -> None:
     dp.message.outer_middleware(session_middleware_factory(Session, bot))
     dp.callback_query.outer_middleware(session_middleware_factory(Session, bot))
 
-    dp.include_router(start_token.router)
+    dp.include_router(start_token)
     dp.include_router(start.router)
     dp.include_router(admin_router)
     dp.include_router(vip.router)


### PR DESCRIPTION
## Summary
- fix router inclusion for start_token

## Testing
- `python -m py_compile mybot/bot.py mybot/handlers/user/start_token.py`


------
https://chatgpt.com/codex/tasks/task_e_684ec27a5dcc8329b9db3323b24d8f61