### PR TITLE
Move VIP tariff config into VIP admin menu

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from utils.user_roles import is_admin, is_vip_member
 from keyboards.admin_vip_kb import get_admin_vip_kb
+from keyboards.admin_vip_config_kb import get_admin_vip_config_kb
 from keyboards.vip_kb import get_vip_kb
 from services import (
     TokenService,
@@ -143,9 +144,9 @@ async def vip_config(callback: CallbackQuery, session: AsyncSession):
     await update_menu(
         callback,
         f"Precio actual del VIP: {price_text}",
-        get_admin_vip_kb(),
+        get_admin_vip_config_kb(),
         session,
-        "admin_vip",
+        "vip_config",
     )
     await callback.answer()
 

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -3,7 +3,6 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 def get_admin_config_kb():
     builder = InlineKeyboardBuilder()
-    builder.button(text="📄 Tarifas", callback_data="config_tarifas")
     builder.button(text="🔙 Volver", callback_data="admin_back")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/keyboards/admin_vip_config_kb.py
+++ b/mybot/keyboards/admin_vip_config_kb.py
@@ -1,0 +1,9 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_vip_config_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📄 Tarifas", callback_data="config_tarifas")
+    builder.button(text="🔙 Volver", callback_data="admin_vip")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/tarifas_kb.py
+++ b/mybot/keyboards/tarifas_kb.py
@@ -4,7 +4,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_tarifas_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="➕ Nueva Tarifa", callback_data="tarifa_new")
-    builder.button(text="🔙 Volver", callback_data="admin_config")
+    builder.button(text="🔙 Volver", callback_data="vip_config")
     builder.adjust(1)
     return builder.as_markup()
 


### PR DESCRIPTION
## Summary
- adjust admin config menu to remove Tarifas option
- add VIP-specific config keyboard
- show tariff management inside VIP config menu
- update tariff navigation to return to VIP config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ec48a4a588329bdabc8ab2d776bba