### PR TITLE
Implement free channel join request handling

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -7,10 +7,12 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from database.setup import init_db, get_session
 
 from handlers import start, free_user
+from handlers.channel_access import router as channel_access_router
 from handlers.user import start_token
 from handlers.vip import menu as vip
 from handlers.admin import admin_router
 from utils.config import BOT_TOKEN
+from services import channel_request_scheduler
 
 
 async def main() -> None:
@@ -30,14 +32,20 @@ async def main() -> None:
 
     dp.message.outer_middleware(session_middleware_factory(Session, bot))
     dp.callback_query.outer_middleware(session_middleware_factory(Session, bot))
+    dp.chat_join_request.outer_middleware(session_middleware_factory(Session, bot))
+    dp.chat_member.outer_middleware(session_middleware_factory(Session, bot))
 
     dp.include_router(start_token)
     dp.include_router(start.router)
     dp.include_router(admin_router)
     dp.include_router(vip.router)
     dp.include_router(free_user.router)
+    dp.include_router(channel_access_router)
+
+    pending_task = asyncio.create_task(channel_request_scheduler(bot, Session))
 
     await dp.start_polling(bot)
+    pending_task.cancel()
 
 
 if __name__ == "__main__":

--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -116,6 +116,21 @@ class ConfigEntry(AsyncAttrs, Base):
     value = Column(String, nullable=True)
 
 
+class BotConfig(AsyncAttrs, Base):
+    __tablename__ = "bot_config"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    free_channel_wait_time_minutes = Column(Integer, default=0)
+
+
+class PendingChannelRequest(AsyncAttrs, Base):
+    __tablename__ = "pending_channel_requests"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, nullable=False)
+    chat_id = Column(BigInteger, nullable=False)
+    request_timestamp = Column(DateTime, default=func.now())
+    approved = Column(Boolean, default=False)
+
+
 # Funciones para manejar el estado del menú del usuario
 async def get_user_menu_state(session, user_id: int) -> str:
     result = await session.execute(select(User).where(User.id == user_id))

--- a/mybot/handlers/channel_access.py
+++ b/mybot/handlers/channel_access.py
@@ -1,0 +1,61 @@
+from aiogram import Router, Bot
+from aiogram.types import ChatJoinRequest, ChatMemberUpdated
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from datetime import datetime
+
+from database.models import PendingChannelRequest, BotConfig
+
+router = Router()
+
+FREE_CHANNEL_ID = -100123456789  # TODO: replace with real channel id
+
+
+@router.chat_join_request()
+async def handle_join_request(event: ChatJoinRequest, bot: Bot, session: AsyncSession):
+    if event.chat.id != FREE_CHANNEL_ID:
+        return
+    req = PendingChannelRequest(
+        user_id=event.from_user.id,
+        chat_id=event.chat.id,
+        request_timestamp=datetime.utcnow(),
+    )
+    session.add(req)
+    await session.commit()
+
+    config = await session.get(BotConfig, 1)
+    wait_minutes = config.free_channel_wait_time_minutes if config else 0
+    await bot.send_message(
+        event.from_user.id,
+        f"Solicitud recibida. Ser\u00e1 aprobada en aproximadamente {wait_minutes} minutos."
+    )
+
+
+@router.chat_member()
+async def handle_chat_member(update: ChatMemberUpdated, bot: Bot, session: AsyncSession):
+    if update.chat.id != FREE_CHANNEL_ID:
+        return
+
+    user_id = update.from_user.id
+    status = update.new_chat_member.status
+    if status in {"member", "administrator", "creator"}:
+        await bot.send_message(user_id, "Tu acceso al canal ha sido confirmado.")
+        stmt = select(PendingChannelRequest).where(
+            PendingChannelRequest.user_id == user_id,
+            PendingChannelRequest.chat_id == update.chat.id,
+        )
+        result = await session.execute(stmt)
+        req = result.scalar_one_or_none()
+        if req:
+            await session.delete(req)
+            await session.commit()
+    elif status in {"kicked", "left"}:
+        stmt = select(PendingChannelRequest).where(
+            PendingChannelRequest.user_id == user_id,
+            PendingChannelRequest.chat_id == update.chat.id,
+        )
+        result = await session.execute(stmt)
+        req = result.scalar_one_or_none()
+        if req:
+            await session.delete(req)
+            await session.commit()

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -7,6 +7,7 @@ from .subscription_service import SubscriptionService
 from .token_service import TokenService
 from .config_service import ConfigService
 from .plan_service import SubscriptionPlanService
+from .scheduler import channel_request_scheduler
 
 __all__ = [
     "AchievementService",
@@ -18,4 +19,5 @@ __all__ = [
     "TokenService",
     "ConfigService",
     "SubscriptionPlanService",
+    "channel_request_scheduler",
 ]

--- a/mybot/services/scheduler.py
+++ b/mybot/services/scheduler.py
@@ -1,0 +1,30 @@
+import asyncio
+from datetime import datetime, timedelta
+from aiogram import Bot
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+from sqlalchemy import select
+
+from database.models import PendingChannelRequest, BotConfig
+
+
+async def channel_request_scheduler(bot: Bot, session_factory: async_sessionmaker[AsyncSession]):
+    while True:
+        async with session_factory() as session:
+            config = await session.get(BotConfig, 1)
+            wait_minutes = config.free_channel_wait_time_minutes if config else 0
+            threshold = datetime.utcnow() - timedelta(minutes=wait_minutes)
+            stmt = select(PendingChannelRequest).where(
+                PendingChannelRequest.approved == False,
+                PendingChannelRequest.request_timestamp <= threshold,
+            )
+            result = await session.execute(stmt)
+            requests = result.scalars().all()
+            for req in requests:
+                try:
+                    await bot.approve_chat_join_request(req.chat_id, req.user_id)
+                    await bot.send_message(req.user_id, "Tu solicitud de acceso ha sido aprobada.")
+                    await session.delete(req)
+                except Exception:
+                    pass
+            await session.commit()
+        await asyncio.sleep(30)


### PR DESCRIPTION
## Summary
- track pending channel join requests in DB
- add bot config options and tables
- handle join requests and member updates
- run background scheduler approving requests
- wire new router and scheduler in bot startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecc78e5e48329b3f79b5487e7afc5