### PR TITLE
Implement VIP token activation flow

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -7,6 +7,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from database.setup import init_db, get_session
 
 from handlers import start, free_user
+from handlers import subscriptions
 from handlers.channel_access import router as channel_access_router
 from handlers.user import start_token
 from handlers.vip import menu as vip
@@ -39,6 +40,7 @@ async def main() -> None:
     dp.include_router(start.router)
     dp.include_router(admin_router)
     dp.include_router(vip.router)
+    dp.include_router(subscriptions.router)
     dp.include_router(free_user.router)
     dp.include_router(channel_access_router)
 

--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -22,6 +22,10 @@ class User(AsyncAttrs, Base):
     last_weekly_mission_reset = Column(DateTime, default=func.now())
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    # Role management and VIP expiration
+    role = Column(String, default="free")
+    vip_expires_at = Column(DateTime, nullable=True)
     
     # ¡NUEVA COLUMNA para el estado del menú!
     menu_state = Column(String, default="root") # e.g., "root", "profile", "missions", "rewards"
@@ -108,6 +112,17 @@ class SubscriptionToken(AsyncAttrs, Base):
     used_by = Column(BigInteger, nullable=True)
     created_at = Column(DateTime, default=func.now())
     used_at = Column(DateTime, nullable=True)
+
+
+class Token(AsyncAttrs, Base):
+    """VIP activation tokens for offline payments."""
+
+    __tablename__ = "tokens"
+
+    token_id = Column(String, primary_key=True)
+    subscription_duration = Column(String, nullable=False)
+    created_at = Column(DateTime, default=func.now())
+    is_used = Column(Boolean, default=False)
 
 
 class ConfigEntry(AsyncAttrs, Base):

--- a/mybot/handlers/subscriptions.py
+++ b/mybot/handlers/subscriptions.py
@@ -1,0 +1,80 @@
+from aiogram import Router, Bot
+from aiogram.filters import CommandStart
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime, timedelta
+
+from services.token_service import validate_token
+from services.subscription_service import SubscriptionService
+from database.models import User
+from utils.config import VIP_CHANNEL_ID as CONFIG_VIP_CHANNEL_ID
+
+router = Router()
+
+# Placeholder channel ID. Replace with actual value if not provided via config
+VIP_CHANNEL_ID = CONFIG_VIP_CHANNEL_ID
+
+
+def _duration_to_timedelta(duration: str) -> timedelta:
+    mapping = {
+        "1_month": 30,
+        "3_months": 90,
+        "6_months": 180,
+        "1_year": 365,
+    }
+    if duration in mapping:
+        return timedelta(days=mapping[duration])
+    if duration.endswith("_days") and duration[:-5].isdigit():
+        return timedelta(days=int(duration[:-5]))
+    return timedelta(days=30)
+
+
+@router.message(CommandStart(deep_link=True))
+async def activate_vip(message: Message, session: AsyncSession, bot: Bot):
+    parts = message.text.split(maxsplit=1)
+    token = parts[1] if len(parts) > 1 else None
+    if not token:
+        return
+
+    subscription_duration = await validate_token(token, session)
+    if not subscription_duration:
+        await message.answer("Token inválido o ya utilizado.")
+        return
+
+    user = await session.get(User, message.from_user.id)
+    if not user:
+        user = User(
+            id=message.from_user.id,
+            username=message.from_user.username,
+            first_name=message.from_user.first_name,
+            last_name=message.from_user.last_name,
+        )
+        session.add(user)
+    user.role = "vip"
+
+    delta = _duration_to_timedelta(subscription_duration)
+    vip_expires_at = datetime.utcnow() + delta
+    user.vip_expires_at = vip_expires_at
+
+    sub_service = SubscriptionService(session)
+    existing = await sub_service.get_subscription(user.id)
+    if existing:
+        existing.expires_at = vip_expires_at
+    else:
+        await sub_service.create_subscription(user.id, vip_expires_at)
+    await session.commit()
+
+    invite_link = None
+    if VIP_CHANNEL_ID:
+        try:
+            link = await bot.create_chat_invite_link(VIP_CHANNEL_ID, member_limit=1)
+            invite_link = link.invite_link
+        except Exception:
+            invite_link = None
+
+    if invite_link:
+        await message.answer(
+            f"¡Tu suscripción VIP está activa! Únete aquí: {invite_link}"
+        )
+    else:
+        await message.answer("¡Tu suscripción VIP está activa!")

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -4,7 +4,7 @@ from .mission_service import MissionService
 from .point_service import PointService
 from .reward_service import RewardService
 from .subscription_service import SubscriptionService
-from .token_service import TokenService
+from .token_service import TokenService, validate_token
 from .config_service import ConfigService
 from .plan_service import SubscriptionPlanService
 from .scheduler import channel_request_scheduler
@@ -17,6 +17,7 @@ __all__ = [
     "RewardService",
     "SubscriptionService",
     "TokenService",
+    "validate_token",
     "ConfigService",
     "SubscriptionPlanService",
     "channel_request_scheduler",


### PR DESCRIPTION
## Summary
- support VIP role and expiration fields in database
- store tokens for VIP activation
- validate tokens to mark them used
- handle `/start <token>` deep links to activate VIP subscription
- wire subscription router into bot startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ecef808bc8329a9daa8405c15ec61