### PR TITLE
Add gain_points handler for VIP game

### DIFF
--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -9,6 +9,7 @@ from keyboards.vip_kb import get_vip_kb
 from keyboards.vip_game_kb import get_game_menu_kb
 from utils.user_roles import is_vip_member
 from utils.keyboard_utils import get_back_keyboard
+from utils.messages import BOT_MESSAGES
 from utils.message_utils import get_profile_message
 from services.subscription_service import SubscriptionService
 from services.mission_service import MissionService
@@ -74,6 +75,22 @@ async def game_profile(callback: CallbackQuery, session: AsyncSession):
 
     await callback.message.edit_text(
         profile_message, reply_markup=get_back_keyboard("vip_game")
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "gain_points")
+async def gain_points(callback: CallbackQuery, session: AsyncSession):
+    """Show information on how to earn points in the game."""
+    if not await is_vip_member(callback.bot, callback.from_user.id):
+        return await callback.answer()
+
+    await callback.message.edit_text(
+        BOT_MESSAGES.get(
+            "gain_points_instructions",
+            "Participa en misiones y actividades para ganar puntos."
+        ),
+        reply_markup=get_back_keyboard("vip_game")
     )
     await callback.answer()
 

--- a/mybot/keyboards/vip_game_kb.py
+++ b/mybot/keyboards/vip_game_kb.py
@@ -5,4 +5,5 @@ def get_game_menu_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="Mi perfil", callback_data="game_profile")
     builder.button(text="Ganar puntos", callback_data="gain_points")
+    builder.adjust(1)
     return builder.as_markup()

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -79,5 +79,6 @@ BOT_MESSAGES = {
     "menu_rewards_text": "¡Es hora de canjear tus puntos! Aquí tienes las recompensas disponibles:",
     "confirm_purchase_message": "¿Estás segur@ de que quieres canjear {reward_name} por {reward_cost} puntos?",
     "purchase_cancelled_message": "Compra cancelada. Puedes seguir explorando otras recompensas.",
+    "gain_points_instructions": "Puedes ganar puntos completando misiones y participando en las actividades del canal.",
     "unrecognized_command_text": "Comando no reconocido. Aquí está el menú principal:"
 }


### PR DESCRIPTION
## Summary
- handle `gain_points` callback in VIP game menu
- add message text for earning points
- tweak VIP game keyboard layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ed03ea37c832993ac1460db7f1fe2