### PR TITLE
Fix profile access in VIP game

### DIFF
--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -59,7 +59,14 @@ async def game_profile(callback: CallbackQuery, session: AsyncSession):
     user_id = callback.from_user.id
     user: User | None = await session.get(User, user_id)
     if not user:
-        return await callback.answer()
+        user = User(
+            id=user_id,
+            username=callback.from_user.username,
+            first_name=callback.from_user.first_name,
+            last_name=callback.from_user.last_name,
+        )
+        session.add(user)
+        await session.commit()
 
     mission_service = MissionService(session)
     active_missions = await mission_service.get_active_missions(user_id=user_id)


### PR DESCRIPTION
## Summary
- create user record during /start flow
- create user if missing when opening VIP profile

## Testing
- `python -m py_compile mybot/handlers/start.py mybot/handlers/vip/menu.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed4ca1b008329ba18d83a29103a61