### PR TITLE
Add VIP subscription management

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -13,7 +13,7 @@ from handlers.user import start_token
 from handlers.vip import menu as vip
 from handlers.admin import admin_router
 from utils.config import BOT_TOKEN
-from services import channel_request_scheduler
+from services import channel_request_scheduler, vip_subscription_scheduler
 
 
 async def main() -> None:
@@ -45,9 +45,11 @@ async def main() -> None:
     dp.include_router(channel_access_router)
 
     pending_task = asyncio.create_task(channel_request_scheduler(bot, Session))
+    vip_task = asyncio.create_task(vip_subscription_scheduler(bot, Session))
 
     await dp.start_polling(bot)
     pending_task.cancel()
+    vip_task.cancel()
 
 
 if __name__ == "__main__":

--- a/mybot/handlers/admin/subscription_plans.py
+++ b/mybot/handlers/admin/subscription_plans.py
@@ -1,77 +1,62 @@
 from aiogram import Router, F
-from aiogram.types import CallbackQuery, Message
+from aiogram.types import Message, CallbackQuery
+from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.state import StatesGroup, State
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from utils.user_roles import is_admin
-from utils.menu_utils import update_menu
-from keyboards.tarifas_kb import get_tarifas_kb, get_duration_kb
+from utils.admin_state import AdminTariffStates
+from keyboards.tarifas_kb import get_duration_kb
 from keyboards.common import get_back_kb
-from services.plan_service import SubscriptionPlanService
+from database.models import Tariff
 
 router = Router()
 
 
-class PlanStates(StatesGroup):
-    waiting_name = State()
-    waiting_price = State()
+@router.message(Command("admin_configure_tariffs"))
+async def admin_configure_tariffs(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.set_state(AdminTariffStates.waiting_for_tariff_duration)
+    await message.answer("Selecciona la duración:", reply_markup=get_duration_kb())
 
 
-@router.callback_query(F.data == "config_tarifas")
-async def tarifas_menu(callback: CallbackQuery, session: AsyncSession):
-    if not is_admin(callback.from_user.id):
-        return await callback.answer()
-    await update_menu(callback, "Gestión de Tarifas", get_tarifas_kb(), session, "config_tarifas")
-    await callback.answer()
-
-
-@router.callback_query(F.data == "tarifa_new")
-async def tarifa_new(callback: CallbackQuery, session: AsyncSession):
-    if not is_admin(callback.from_user.id):
-        return await callback.answer()
-    await update_menu(callback, "Selecciona la duración", get_duration_kb(), session, "config_tarifas_duration")
-    await callback.answer()
-
-
-@router.callback_query(F.data.startswith("plan_dur_"))
-async def select_duration(callback: CallbackQuery, state: FSMContext):
+@router.callback_query(AdminTariffStates.waiting_for_tariff_duration)
+async def tariff_duration_selected(callback: CallbackQuery, state: FSMContext):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
     duration = int(callback.data.split("_")[-1])
     await state.update_data(duration_days=duration)
-    await callback.message.edit_text("Introduce el nombre de la tarifa:")
-    await state.set_state(PlanStates.waiting_name)
+    await state.set_state(AdminTariffStates.waiting_for_tariff_price)
+    await callback.message.edit_text("Ingresa el precio de la tarifa:")
     await callback.answer()
 
 
-@router.message(PlanStates.waiting_name)
-async def plan_name(message: Message, state: FSMContext):
+@router.message(AdminTariffStates.waiting_for_tariff_price)
+async def tariff_price(message: Message, state: FSMContext):
     if not is_admin(message.from_user.id):
         return
-    await state.update_data(name=message.text)
-    await message.delete()
-    await message.answer("Introduce el precio:")
-    await state.set_state(PlanStates.waiting_price)
-
-
-@router.message(PlanStates.waiting_price)
-async def plan_price(message: Message, state: FSMContext, session: AsyncSession):
-    if not is_admin(message.from_user.id):
-        return
-    data = await state.get_data()
     try:
         price = int(message.text)
     except ValueError:
         await message.answer("Precio inválido. Ingresa un número.")
         return
-    service = SubscriptionPlanService(session)
-    await message.delete()
-    plan = await service.create_plan(
-        message.from_user.id, data["name"], price, data["duration_days"]
+    await state.update_data(price=price)
+    await state.set_state(AdminTariffStates.waiting_for_tariff_name)
+    await message.answer("Ingresa el nombre de la tarifa:")
+
+
+@router.message(AdminTariffStates.waiting_for_tariff_name)
+async def tariff_name(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    tariff = Tariff(
+        name=message.text,
+        duration_days=data["duration_days"],
+        price=data["price"],
     )
-    await message.answer(
-        f"Tarifa creada:\nNombre: {plan.name}\nPrecio: {plan.price}\nDuración: {plan.duration_days} días",
-        reply_markup=get_back_kb("config_tarifas"),
-    )
+    session.add(tariff)
+    await session.commit()
+    await message.answer("Tarifa generada.", reply_markup=get_back_kb())
     await state.clear()

--- a/mybot/keyboards/admin_vip_config_kb.py
+++ b/mybot/keyboards/admin_vip_config_kb.py
@@ -7,3 +7,11 @@ def get_admin_vip_config_kb():
     builder.button(text="🔙 Volver", callback_data="admin_vip")
     builder.adjust(1)
     return builder.as_markup()
+
+
+def get_tariff_select_kb(tariffs):
+    builder = InlineKeyboardBuilder()
+    for tariff in tariffs:
+        builder.button(text=tariff.name, callback_data=f"generate_token_{tariff.id}")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/tarifas_kb.py
+++ b/mybot/keyboards/tarifas_kb.py
@@ -12,6 +12,7 @@ def get_tarifas_kb():
 def get_duration_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="1 D\u00eda", callback_data="plan_dur_1")
+    builder.button(text="2 D\u00edas", callback_data="plan_dur_2")
     builder.button(text="1 Semana", callback_data="plan_dur_7")
     builder.button(text="2 Semanas", callback_data="plan_dur_14")
     builder.button(text="1 Mes", callback_data="plan_dur_30")

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -7,7 +7,7 @@ from .subscription_service import SubscriptionService
 from .token_service import TokenService, validate_token
 from .config_service import ConfigService
 from .plan_service import SubscriptionPlanService
-from .scheduler import channel_request_scheduler
+from .scheduler import channel_request_scheduler, vip_subscription_scheduler
 
 __all__ = [
     "AchievementService",
@@ -21,4 +21,5 @@ __all__ = [
     "ConfigService",
     "SubscriptionPlanService",
     "channel_request_scheduler",
+    "vip_subscription_scheduler",
 ]

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from typing import Dict, List
 
+from aiogram.fsm.state import State, StatesGroup
+
 # Simple in-memory stack of admin menu states per user
 _user_states: Dict[int, List[str]] = defaultdict(list)
 
@@ -31,3 +33,11 @@ def current_state(user_id: int) -> str:
     """Return the current state for the user."""
     stack = _user_states.get(user_id, ["main"])
     return stack[-1]
+
+
+class AdminTariffStates(StatesGroup):
+    """States for the admin tariff configuration flow."""
+
+    waiting_for_tariff_duration = State()
+    waiting_for_tariff_price = State()
+    waiting_for_tariff_name = State()


### PR DESCRIPTION
## Summary
- manage admin tariff states with FSM
- add tariff and token models with relationships
- configure tariffs via command
- generate deep-link tokens from admin menu
- activate VIP subscriptions from deep links
- monitor VIP expirations in scheduler

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684edb353e508329a9ec53173016f44a