### PR TITLE
Fix admin menu skip import

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -1,5 +1,8 @@
 from aiogram import Router, F, Bot
-from aiogram.exceptions import SkipHandler
+try:
+    from aiogram.exceptions import SkipHandler
+except ImportError:  # For aiogram >=3.12.0
+    from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import Message, CallbackQuery
 from aiogram.filters import CommandStart, Command
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
## Summary
- fix SkipHandler import for aiogram >=3.12

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ef037ce308329a7a32895f519d25d