### PR TITLE
Fix incorrect SkipHandler import

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -1,5 +1,5 @@
 from aiogram import Router, F, Bot
-from aiogram.exceptions import SkipHandler
+from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import Message, CallbackQuery
 from aiogram.filters import CommandStart, Command
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
## Summary
- fix SkipHandler import path for aiogram 3

## Testing
- `pip install -r requirements.txt`
- `BOT_TOKEN=placeholder python mybot/bot.py` *(fails due to invalid token)*

------
https://chatgpt.com/codex/tasks/task_e_684efb7907908329950986c267e63d81