### PR TITLE
Implement free game menu

### DIFF
--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -21,3 +21,13 @@ async def subscription_menu(message: Message):
 @router.callback_query(F.data == "free_button")
 async def request_access(callback: CallbackQuery):
     await callback.answer("Acceso solicitado", show_alert=True)
+
+
+@router.callback_query(F.data == "free_game")
+async def free_game(callback: CallbackQuery):
+    """Simple placeholder for the free version of the game."""
+    await callback.message.edit_text(
+        "Versión gratuita del Juego del Diván. ¡Disfruta!",
+        reply_markup=get_subscription_kb(),
+    )
+    await callback.answer()

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -5,6 +5,9 @@ def get_subscription_kb():
     """Return a minimal free-user menu."""
 
     builder = InlineKeyboardBuilder()
-    # Single button for free channel subscribers or access requests
+    # Button to request access or interact in the free channel
     builder.button(text="Botón de suscriptor free", callback_data="free_button")
+    # Simplified game available for free users
+    builder.button(text="🎮 Juego del Diván Lite", callback_data="free_game")
+    builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- add Diván Lite option to the free user menu
- handle the `free_game` callback for a simple placeholder message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f19b345888329a093d8a7436a640a