### PR TITLE
Fix menu update error

### DIFF
--- a/mybot/utils/menu_utils.py
+++ b/mybot/utils/menu_utils.py
@@ -1,4 +1,5 @@
 from aiogram.types import Message, CallbackQuery
+from aiogram.exceptions import TelegramBadRequest
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import set_user_menu_state
 
@@ -11,5 +12,9 @@ async def send_menu(message: Message, text: str, reply_markup, session: AsyncSes
 
 async def update_menu(callback: CallbackQuery, text: str, reply_markup, session: AsyncSession, state: str) -> None:
     """Edit the current menu message and update the user's state."""
-    await callback.message.edit_text(text, reply_markup=reply_markup)
+    try:
+        await callback.message.edit_text(text, reply_markup=reply_markup)
+    except TelegramBadRequest as exc:
+        if "message is not modified" not in str(exc).lower():
+            raise
     await set_user_menu_state(session, callback.from_user.id, state)


### PR DESCRIPTION
## Summary
- handle `message is not modified` errors in `update_menu`

## Testing
- `python -m compileall -q mybot`

------
https://chatgpt.com/codex/tasks/task_e_684f1efae2608329bf3cd3c54610e145