### PR TITLE
Add channel admin menu

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -151,6 +151,13 @@ class BotConfig(AsyncAttrs, Base):
     free_channel_wait_time_minutes = Column(Integer, default=0)
 
 
+class Channel(AsyncAttrs, Base):
+    __tablename__ = "channels"
+    id = Column(BigInteger, primary_key=True)  # Telegram chat ID
+    title = Column(String, nullable=True)
+
+
+
 class PendingChannelRequest(AsyncAttrs, Base):
     __tablename__ = "pending_channel_requests"
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -2,6 +2,7 @@ from .admin_menu import router as admin_router
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
+from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
 
@@ -10,6 +11,7 @@ __all__ = [
     "vip_router",
     "free_router",
     "config_router",
+    "channel_admin_router",
     "subscription_plans_router",
     "game_admin_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -24,6 +24,7 @@ from database.models import get_user_menu_state
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
+from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
 from handlers.vip.gamification import router as game_router
 from .game_admin import router as game_admin_router
@@ -32,6 +33,7 @@ router = Router()
 router.include_router(vip_router)
 router.include_router(free_router)
 router.include_router(config_router)
+router.include_router(channel_admin_router)
 router.include_router(subscription_plans_router)
 router.include_router(game_router)
 router.include_router(game_admin_router)
@@ -176,6 +178,8 @@ IGNORED_CALLBACKS = {
     "admin_free",
     "admin_game",
     "admin_config",
+    "admin_channels",
+    "admin_wait_time",
     "admin_back",
     "admin_manage_users",
     "admin_manage_content",

--- a/mybot/handlers/admin/channel_admin.py
+++ b/mybot/handlers/admin/channel_admin.py
@@ -1,0 +1,104 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import StatesGroup, State
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.user_roles import is_admin
+from utils.menu_utils import update_menu
+from keyboards.admin_channels_kb import get_admin_channels_kb, get_wait_time_kb
+from keyboards.common import get_back_kb
+from services.channel_service import ChannelService
+from database.models import BotConfig
+
+router = Router()
+
+
+class ChannelStates(StatesGroup):
+    waiting_for_id = State()
+
+
+@router.callback_query(F.data == "admin_channels")
+async def channels_menu(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await update_menu(
+        callback,
+        "Administrar canales",
+        get_admin_channels_kb(),
+        session,
+        "admin_channels",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_add_channel")
+async def prompt_add_channel(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Reenvía un mensaje del canal o envía su ID numérico.",
+        reply_markup=get_back_kb("admin_channels"),
+    )
+    await state.set_state(ChannelStates.waiting_for_id)
+    await callback.answer()
+
+
+@router.message(ChannelStates.waiting_for_id)
+async def add_channel(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    chat_id = None
+    title = None
+    if message.forward_from_chat:
+        chat_id = message.forward_from_chat.id
+        title = message.forward_from_chat.title
+    else:
+        try:
+            chat_id = int(message.text.strip())
+        except (TypeError, ValueError):
+            await message.answer("No se pudo obtener el ID del canal. Intenta de nuevo.")
+            return
+    service = ChannelService(session)
+    await service.add_channel(chat_id, title)
+    await message.answer(
+        f"Canal {chat_id} agregado.", reply_markup=get_admin_channels_kb()
+    )
+    await state.clear()
+
+
+@router.callback_query(F.data == "admin_wait_time")
+async def wait_time_menu(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    config = await session.get(BotConfig, 1)
+    current = config.free_channel_wait_time_minutes if config else 0
+    await update_menu(
+        callback,
+        f"Tiempo actual: {current} minutos",
+        get_wait_time_kb(),
+        session,
+        "admin_wait_time",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("wait_"))
+async def set_wait_time(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    minutes = int(callback.data.split("_")[1])
+    config = await session.get(BotConfig, 1)
+    if not config:
+        config = BotConfig(id=1)
+        session.add(config)
+    config.free_channel_wait_time_minutes = minutes
+    await session.commit()
+    await update_menu(
+        callback,
+        f"Tiempo actualizado a {minutes} minutos.",
+        get_admin_channels_kb(),
+        session,
+        "admin_channels",
+    )
+    await callback.answer()

--- a/mybot/keyboards/admin_channels_kb.py
+++ b/mybot/keyboards/admin_channels_kb.py
@@ -1,0 +1,23 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_channels_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="➕ Agregar Canal", callback_data="admin_add_channel")
+    builder.button(text="⏱ Configurar Espera", callback_data="admin_wait_time")
+    builder.button(text="🔙 Volver", callback_data="admin_back")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_wait_time_kb():
+    builder = InlineKeyboardBuilder()
+    options = [0, 5, 10, 15, 20, 60, 120, 180]
+    for m in options:
+        label = f"{m} min" if m < 60 else f"{m//60} h"
+        if m == 0:
+            label = "0 min"
+        builder.button(text=label, callback_data=f"wait_{m}")
+    builder.button(text="🔙 Volver", callback_data="admin_channels")
+    builder.adjust(3)
+    return builder.as_markup()

--- a/mybot/keyboards/admin_main_kb.py
+++ b/mybot/keyboards/admin_main_kb.py
@@ -6,6 +6,7 @@ def get_admin_main_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="📢 Canal VIP", callback_data="admin_vip")
     builder.button(text="💬 Canal Free", callback_data="admin_free")
+    builder.button(text="📣 Administrar Canales", callback_data="admin_channels")
     builder.button(text="🎮 Juego Kinky", callback_data="admin_game")
     builder.button(text="🛠 Configuración del Bot", callback_data="admin_config")
     builder.button(text="🔙 Volver", callback_data="admin_back")

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -7,6 +7,7 @@ from .subscription_service import SubscriptionService
 from .token_service import TokenService, validate_token
 from .config_service import ConfigService
 from .plan_service import SubscriptionPlanService
+from .channel_service import ChannelService
 from .scheduler import channel_request_scheduler, vip_subscription_scheduler
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "validate_token",
     "ConfigService",
     "SubscriptionPlanService",
+    "ChannelService",
     "channel_request_scheduler",
     "vip_subscription_scheduler",
 ]

--- a/mybot/services/channel_service.py
+++ b/mybot/services/channel_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from database.models import Channel
+
+
+class ChannelService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def add_channel(self, chat_id: int, title: str | None = None) -> Channel:
+        channel = await self.session.get(Channel, chat_id)
+        if channel:
+            if title:
+                channel.title = title
+        else:
+            channel = Channel(id=chat_id, title=title)
+            self.session.add(channel)
+        await self.session.commit()
+        await self.session.refresh(channel)
+        return channel
+
+    async def list_channels(self) -> list[Channel]:
+        result = await self.session.execute(select(Channel))
+        return list(result.scalars().all())


### PR DESCRIPTION
## Summary
- extend admin options with 'Administrar Canales'
- add channel management keyboard and handlers
- create `Channel` model and service
- expose `ChannelService`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f1fe6f8588329ba6d5bc815ca5aef