### PR TITLE
Add admin mission management

### DIFF
--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -60,3 +60,14 @@ class AdminConfigStates(StatesGroup):
     """States for bot configuration options."""
 
     waiting_for_reaction_buttons = State()
+
+
+class AdminMissionStates(StatesGroup):
+    """States for creating missions from the admin panel."""
+
+    creating_mission_name = State()
+    creating_mission_description = State()
+    creating_mission_points = State()
+    creating_mission_type = State()
+    creating_mission_requires_action = State()
+    creating_mission_action_data = State()


### PR DESCRIPTION
## Summary
- allow creating and toggling missions from admin menu
- add FSM states for mission creation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5ad8428c8329a588cf016e24049e