### PR TITLE
Implement achievement tables and logic

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -48,6 +48,23 @@ class Reward(AsyncAttrs, Base):
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=func.now())
 
+
+class Achievement(AsyncAttrs, Base):
+    __tablename__ = "achievements"
+    id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    condition_type = Column(String, nullable=False)
+    condition_value = Column(Integer, nullable=False)
+    reward_text = Column(String, nullable=False)
+    created_at = Column(DateTime, default=func.now())
+
+
+class UserAchievement(AsyncAttrs, Base):
+    __tablename__ = "user_achievements"
+    user_id = Column(BigInteger, ForeignKey("users.id"), primary_key=True)
+    achievement_id = Column(String, ForeignKey("achievements.id"), primary_key=True)
+    unlocked_at = Column(DateTime, default=func.now())
+
 class Mission(AsyncAttrs, Base):
     __tablename__ = "missions"
     id = Column(String, primary_key=True, unique=True) # e.g., 'daily_login', 'event_trivia_challenge'
@@ -87,6 +104,8 @@ class UserProgress(AsyncAttrs, Base):
     last_activity_at = Column(DateTime, default=func.now())
     last_checkin_at = Column(DateTime, nullable=True)
     last_notified_points = Column(Float, default=0)
+    messages_sent = Column(Integer, default=0)
+    checkin_streak = Column(Integer, default=0)
 
 
 class InviteToken(AsyncAttrs, Base):

--- a/mybot/handlers/subscriptions.py
+++ b/mybot/handlers/subscriptions.py
@@ -8,6 +8,7 @@ from services.token_service import validate_token
 from services.subscription_service import SubscriptionService
 from database.models import User
 from utils.config import VIP_CHANNEL_ID as CONFIG_VIP_CHANNEL_ID
+from services.achievement_service import AchievementService
 
 router = Router()
 
@@ -63,6 +64,8 @@ async def activate_vip(message: Message, session: AsyncSession, bot: Bot):
     else:
         await sub_service.create_subscription(user.id, vip_expires_at)
     await session.commit()
+    ach_service = AchievementService(session)
+    await ach_service.check_vip_achievement(user.id, bot=bot)
 
     invite_link = None
     if VIP_CHANNEL_ID:

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import User
 from services.token_service import TokenService
+from services.achievement_service import AchievementService
 from utils.config import VIP_CHANNEL_ID
 
 router = Router()
@@ -40,6 +41,8 @@ async def start_with_token(message: Message, command: CommandObject, session: As
     user.vip_expires_at = datetime.utcnow() + timedelta(days=duration)
     user.last_reminder_sent_at = None
     await session.commit()
+    ach_service = AchievementService(session)
+    await ach_service.check_vip_achievement(user.id, bot=bot)
 
     invite_link = None
     if VIP_CHANNEL_ID_CONST:

--- a/mybot/services/token_service.py
+++ b/mybot/services/token_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from database.models import InviteToken, SubscriptionToken, Token, Tariff
+from services.achievement_service import AchievementService
 
 
 class TokenService:
@@ -45,6 +46,8 @@ class TokenService:
         obj.used_by = user_id
         obj.used_at = datetime.utcnow()
         await self.session.commit()
+        ach_service = AchievementService(self.session)
+        await ach_service.check_invite_achievements(obj.created_by)
         return True
 
     async def create_subscription_token(self, plan_id: int, created_by: int) -> SubscriptionToken:


### PR DESCRIPTION
## Summary
- add achievements and user achievements models
- track message count and checkin streak in `UserProgress`
- grant achievements for messages, invites, check-ins and VIP subscriptions
- notify users when unlocking achievements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f5d49a5b0832994c47d983389a7c8