### PR TITLE
Implement VIP menu integration with gamification

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -11,6 +11,7 @@ from handlers import subscriptions
 from handlers.channel_access import router as channel_access_router
 from handlers.user import start_token
 from handlers.vip import menu as vip
+from handlers.vip import gamification
 from handlers.admin import admin_router
 from utils.config import BOT_TOKEN
 from services import channel_request_scheduler, vip_subscription_scheduler
@@ -47,6 +48,7 @@ async def main() -> None:
     dp.include_router(start.router)
     dp.include_router(admin_router)
     dp.include_router(vip.router)
+    dp.include_router(gamification.router)
     dp.include_router(subscriptions.router)
     dp.include_router(free_user.router)
     dp.include_router(channel_access_router)


### PR DESCRIPTION
## Summary
- link the gamification router so VIP users can access the game menu
- open the full gamification menu from the VIP menu
- show formatted expiration date in the "Mi Suscripción" option

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f6034979483298c84a96d48a7d237