### PR TITLE
Add ACHIEVEMENT alias

### DIFF
--- a/mybot/services/achievement_service.py
+++ b/mybot/services/achievement_service.py
@@ -48,6 +48,8 @@ PREDEFINED_ACHIEVEMENTS = [
 
 # Convenience mapping by ID for easy lookups (used in profile views)
 ACHIEVEMENTS = {a["id"]: a for a in PREDEFINED_ACHIEVEMENTS}
+# Backwards compatibility alias in case external code imports singular name
+ACHIEVEMENT = ACHIEVEMENTS
 
 
 class AchievementService:

--- a/old_gamificacion/services/achievement_service.py
+++ b/old_gamificacion/services/achievement_service.py
@@ -11,6 +11,8 @@ ACHIEVEMENTS = {
     "trivia_master": {"name": "Experto en Trivias", "icon": "🧠"}, # Requires trivia system
     "contributor": {"name": "Colaborador Activo", "icon": "🤝"} # Requires more complex engagement
 }
+# Backwards compatibility alias for singular constant name
+ACHIEVEMENT = ACHIEVEMENTS
 
 class AchievementService:
     def __init__(self, session: AsyncSession):


### PR DESCRIPTION
## Summary
- alias `ACHIEVEMENT` to existing `ACHIEVEMENTS` constant in both versions of achievement service

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f7788df4883299dad0d3b318125c3