### PR TITLE
Add challenge engagement system

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -204,6 +204,28 @@ class PendingChannelRequest(AsyncAttrs, Base):
     approved = Column(Boolean, default=False)
 
 
+class Challenge(AsyncAttrs, Base):
+    __tablename__ = "challenges"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    type = Column(String, nullable=False)  # daily, weekly, monthly
+    goal_type = Column(String, nullable=False)  # messages, reactions, checkins
+    goal_value = Column(Integer, nullable=False)
+    start_date = Column(DateTime, nullable=False)
+    end_date = Column(DateTime, nullable=False)
+
+
+class UserChallengeProgress(AsyncAttrs, Base):
+    __tablename__ = "user_challenge_progress"
+
+    user_id = Column(BigInteger, ForeignKey("users.id"), primary_key=True)
+    challenge_id = Column(Integer, ForeignKey("challenges.id"), primary_key=True)
+    current_value = Column(Integer, default=0)
+    completed = Column(Boolean, default=False)
+    completed_at = Column(DateTime, nullable=True)
+
+
 # Funciones para manejar el estado del menú del usuario
 async def get_user_menu_state(session, user_id: int) -> str:
     result = await session.execute(select(User).where(User.id == user_id))

--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -353,10 +353,22 @@ async def show_ranking_from_reply_keyboard(message: Message, session: AsyncSessi
 async def handle_daily_checkin(message: Message, session: AsyncSession, bot: Bot):
     service = PointService(session)
     success, progress = await service.daily_checkin(message.from_user.id, bot)
+    mission_service = MissionService(session)
+    completed_challenges = []
+    if success:
+        completed_challenges = await mission_service.increment_challenge_progress(
+            message.from_user.id,
+            "checkins",
+            bot=bot,
+        )
     if success:
         await message.answer(
             BOT_MESSAGES["checkin_success"].format(points=10)
         )
+        for ch in completed_challenges:
+            await message.answer(
+                f"🎯 ¡Desafío {ch.type} completado! +100 puntos"
+            )
     else:
         await message.answer(BOT_MESSAGES["checkin_already_done"])
 


### PR DESCRIPTION
## Summary
- create `Challenge` and `UserChallengeProgress` models
- extend `MissionService` with challenge utilities
- update `PointsMiddleware` to track challenge progress
- notify users of completed challenges
- update checkin handler with challenge logic

## Testing
- `python -m py_compile mybot/database/models.py mybot/services/mission_service.py mybot/middlewares/points_middleware.py mybot/handlers/vip/gamification.py`

------
https://chatgpt.com/codex/tasks/task_e_684f7933a04c832997277576018a9966