### PR TITLE
Fix gamification router error

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -26,7 +26,6 @@ from .free_menu import router as free_router
 from .config_menu import router as config_router
 from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
-from handlers.vip.gamification import router as game_router
 from .game_admin import router as game_admin_router
 
 router = Router()
@@ -35,7 +34,6 @@ router.include_router(free_router)
 router.include_router(config_router)
 router.include_router(channel_admin_router)
 router.include_router(subscription_plans_router)
-router.include_router(game_router)
 router.include_router(game_admin_router)
 
 


### PR DESCRIPTION
## Summary
- remove duplicate gamification router include

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f817f57c0832984d5f3b2d2ca4677