### PR TITLE
Fix missing import error

### DIFF
--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -2,6 +2,7 @@
 from database.models import User, Mission, Reward, UserAchievement
 from services.level_service import LevelService
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from services.achievement_service import ACHIEVEMENTS
 from utils.messages import BOT_MESSAGES
 import datetime


### PR DESCRIPTION
## Summary
- fix missing sqlalchemy `select` import in `get_profile_message`

## Testing
- `python -m py_compile mybot/utils/message_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684fe524d3508329be76cb0d93ac81bd