### PR TITLE
Fix admin menu import error

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -1,5 +1,5 @@
 from aiogram import Router, F, Bot
-from aiogram.exceptions import SkipHandler
+from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import Message, CallbackQuery
 from aiogram.filters import CommandStart, Command
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
## Summary
- correct SkipHandler import path for aiogram v3

## Testing
- `python3 -m py_compile mybot/handlers/admin/admin_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_6850249aa6448329a829c835cb7f3e82