### PR TITLE
Fix tariff config menu and token generation

### DIFF
--- a/mybot/keyboards/admin_vip_kb.py
+++ b/mybot/keyboards/admin_vip_kb.py
@@ -5,6 +5,7 @@ def get_admin_vip_kb() -> InlineKeyboardBuilder:
     builder = InlineKeyboardBuilder()
     builder.button(text="📊 Estadísticas", callback_data="vip_stats")
     builder.button(text="🔗 Crear Invitación", callback_data="vip_invite")
+    builder.button(text="🔑 Generar Token", callback_data="vip_generate_token")
     builder.button(text="🔗 Generar Enlace", callback_data="vip_generate_link")
     builder.button(text="👥 Suscriptores", callback_data="vip_manage")
     builder.button(text="⚙️ Configuración", callback_data="vip_config")


### PR DESCRIPTION
## Summary
- enable tariff config callback in admin menu
- list existing tariffs and allow creating new ones
- add button for token generation from tariffs
- add handler to show tariff options for token generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685024fbb18c8329995abb2612171713