### PR TITLE
Handle invalid Unicode inputs

### DIFF
--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -4,6 +4,7 @@ from aiogram.types import Message
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import User
+from utils.text_utils import sanitize_text
 
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.subscription_kb import get_subscription_kb
@@ -23,9 +24,9 @@ async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
     if not user:
         user = User(
             id=user_id,
-            username=message.from_user.username,
-            first_name=message.from_user.first_name,
-            last_name=message.from_user.last_name,
+            username=sanitize_text(message.from_user.username),
+            first_name=sanitize_text(message.from_user.first_name),
+            last_name=sanitize_text(message.from_user.last_name),
         )
         session.add(user)
         await session.commit()

--- a/mybot/handlers/subscriptions.py
+++ b/mybot/handlers/subscriptions.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from services.token_service import validate_token
 from services.subscription_service import SubscriptionService
 from database.models import User
+from utils.text_utils import sanitize_text
 from utils.config import VIP_CHANNEL_ID as CONFIG_VIP_CHANNEL_ID
 from services.achievement_service import AchievementService
 
@@ -46,9 +47,9 @@ async def activate_vip(message: Message, session: AsyncSession, bot: Bot):
     if not user:
         user = User(
             id=message.from_user.id,
-            username=message.from_user.username,
-            first_name=message.from_user.first_name,
-            last_name=message.from_user.last_name,
+            username=sanitize_text(message.from_user.username),
+            first_name=sanitize_text(message.from_user.first_name),
+            last_name=sanitize_text(message.from_user.last_name),
         )
         session.add(user)
     user.role = "vip"

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -6,6 +6,7 @@ from aiogram.filters.command import CommandObject
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import User
+from utils.text_utils import sanitize_text
 from services.token_service import TokenService
 from services.achievement_service import AchievementService
 from utils.config import VIP_CHANNEL_ID
@@ -31,9 +32,9 @@ async def start_with_token(message: Message, command: CommandObject, session: As
     if not user:
         user = User(
             id=message.from_user.id,
-            username=message.from_user.username,
-            first_name=message.from_user.first_name,
-            last_name=message.from_user.last_name,
+            username=sanitize_text(message.from_user.username),
+            first_name=sanitize_text(message.from_user.first_name),
+            last_name=sanitize_text(message.from_user.last_name),
         )
         session.add(user)
 

--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -10,6 +10,7 @@ from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from database.models import User, Mission, Reward, get_user_menu_state, set_user_menu_state
+from utils.text_utils import sanitize_text
 from services.point_service import PointService
 from services.achievement_service import AchievementService, ACHIEVEMENTS
 from services.mission_service import MissionService
@@ -63,9 +64,9 @@ async def menu_callback_handler(callback: CallbackQuery, session: AsyncSession):
         if not user:
             user = User(
                 id=user_id,
-                username=callback.from_user.username,
-                first_name=callback.from_user.first_name,
-                last_name=callback.from_user.last_name,
+                username=sanitize_text(callback.from_user.username),
+                first_name=sanitize_text(callback.from_user.first_name),
+                last_name=sanitize_text(callback.from_user.last_name),
             )
             session.add(user)
             await session.commit()

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -13,6 +13,7 @@ from utils.message_utils import get_profile_message
 from services.subscription_service import SubscriptionService
 from services.mission_service import MissionService
 from database.models import User, set_user_menu_state
+from utils.text_utils import sanitize_text
 
 router = Router()
 
@@ -67,9 +68,9 @@ async def game_profile(callback: CallbackQuery, session: AsyncSession):
     if not user:
         user = User(
             id=user_id,
-            username=callback.from_user.username,
-            first_name=callback.from_user.first_name,
-            last_name=callback.from_user.last_name,
+            username=sanitize_text(callback.from_user.username),
+            first_name=sanitize_text(callback.from_user.first_name),
+            last_name=sanitize_text(callback.from_user.last_name),
         )
         session.add(user)
         await session.commit()

--- a/mybot/services/channel_service.py
+++ b/mybot/services/channel_service.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from database.models import Channel
+from utils.text_utils import sanitize_text
 
 
 class ChannelService:
@@ -12,11 +13,12 @@ class ChannelService:
 
     async def add_channel(self, chat_id: int, title: str | None = None) -> Channel:
         channel = await self.session.get(Channel, chat_id)
+        clean_title = sanitize_text(title) if title is not None else None
         if channel:
-            if title:
-                channel.title = title
+            if clean_title:
+                channel.title = clean_title
         else:
-            channel = Channel(id=chat_id, title=title)
+            channel = Channel(id=chat_id, title=clean_title)
             self.session.add(channel)
         await self.session.commit()
         await self.session.refresh(channel)

--- a/mybot/services/plan_service.py
+++ b/mybot/services/plan_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from database.models import SubscriptionPlan
+from utils.text_utils import sanitize_text
 
 
 class SubscriptionPlanService:
@@ -13,7 +14,7 @@ class SubscriptionPlanService:
 
     async def create_plan(self, created_by: int, name: str, price: int, duration_days: int) -> SubscriptionPlan:
         plan = SubscriptionPlan(
-            name=name,
+            name=sanitize_text(name),
             price=price,
             duration_days=duration_days,
             created_by=created_by,

--- a/mybot/services/reward_service.py
+++ b/mybot/services/reward_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from database.models import Reward, User
+from utils.text_utils import sanitize_text
 import logging
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,12 @@ class RewardService:
         return True, "Compra exitosa. ¡Disfruta tu recompensa!"
 
     async def create_reward(self, name: str, description: str, cost: int, stock: int = -1) -> Reward:
-        new_reward = Reward(name=name, description=description, cost=cost, stock=stock)
+        new_reward = Reward(
+            name=sanitize_text(name),
+            description=sanitize_text(description),
+            cost=cost,
+            stock=stock,
+        )
         self.session.add(new_reward)
         await self.session.commit()
         await self.session.refresh(new_reward)

--- a/mybot/utils/text_utils.py
+++ b/mybot/utils/text_utils.py
@@ -1,0 +1,6 @@
+def sanitize_text(value: str | None) -> str | None:
+    """Remove characters that cannot be encoded in UTF-8."""
+    if value is None:
+        return None
+    return value.encode("utf-8", "ignore").decode("utf-8", "ignore")
+


### PR DESCRIPTION
## Summary
- sanitize text data before saving to the database
- use sanitation when creating User, Channel, Reward and Plan entries

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685031e19b04832988273522301caddc