### PR TITLE
Implement configurable VIP subscription messages

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -1,17 +1,24 @@
 from aiogram import Router, F, Bot
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, Message
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from utils.user_roles import is_admin, is_vip_member
 from keyboards.admin_vip_kb import get_admin_vip_kb
-from keyboards.admin_vip_config_kb import get_admin_vip_config_kb, get_tariff_select_kb
+from keyboards.admin_vip_config_kb import (
+    get_admin_vip_config_kb,
+    get_tariff_select_kb,
+    get_vip_messages_kb,
+)
 from keyboards.vip_kb import get_vip_kb
+from utils.keyboard_utils import get_back_keyboard
 from services import (
     SubscriptionService,
     ConfigService,
 )
+from utils.admin_state import AdminVipMessageStates
+from aiogram.fsm.context import FSMContext
 from database.models import Tariff
 from utils.menu_utils import update_menu
 
@@ -107,6 +114,72 @@ async def vip_config(callback: CallbackQuery, session: AsyncSession):
         "vip_config",
     )
     await callback.answer()
+
+
+@router.callback_query(F.data == "vip_config_messages")
+async def vip_config_messages(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    config = ConfigService(session)
+    reminder = await config.get_value("vip_reminder_message") or "Tu suscripción VIP expira pronto."
+    farewell = await config.get_value("vip_farewell_message") or "Tu suscripción VIP ha expirado."
+    text = (
+        "Mensajes VIP actuales:\n"
+        f"Recordatorio: {reminder}\n\n"
+        f"Despedida: {farewell}"
+    )
+    await update_menu(
+        callback,
+        text,
+        get_vip_messages_kb(),
+        session,
+        "vip_message_config",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "edit_vip_reminder")
+async def prompt_vip_reminder(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Envía el nuevo mensaje de recordatorio:",
+        reply_markup=get_back_keyboard("vip_config_messages"),
+    )
+    await state.set_state(AdminVipMessageStates.waiting_for_reminder_message)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "edit_vip_farewell")
+async def prompt_vip_farewell(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Envía el nuevo mensaje de despedida:",
+        reply_markup=get_back_keyboard("vip_config_messages"),
+    )
+    await state.set_state(AdminVipMessageStates.waiting_for_farewell_message)
+    await callback.answer()
+
+
+@router.message(AdminVipMessageStates.waiting_for_reminder_message)
+async def set_vip_reminder(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    config = ConfigService(session)
+    await config.set_value("vip_reminder_message", message.text)
+    await message.answer("Mensaje de recordatorio actualizado.", reply_markup=get_vip_messages_kb())
+    await state.clear()
+
+
+@router.message(AdminVipMessageStates.waiting_for_farewell_message)
+async def set_vip_farewell(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    config = ConfigService(session)
+    await config.set_value("vip_farewell_message", message.text)
+    await message.answer("Mensaje de despedida actualizado.", reply_markup=get_vip_messages_kb())
+    await state.clear()
 
 
 @router.callback_query(F.data == "vip_game")

--- a/mybot/handlers/subscriptions.py
+++ b/mybot/handlers/subscriptions.py
@@ -16,13 +16,15 @@ router = Router()
 VIP_CHANNEL_ID = CONFIG_VIP_CHANNEL_ID
 
 
-def _duration_to_timedelta(duration: str) -> timedelta:
+def _duration_to_timedelta(duration: int | str) -> timedelta:
     mapping = {
         "1_month": 30,
         "3_months": 90,
         "6_months": 180,
         "1_year": 365,
     }
+    if isinstance(duration, int):
+        return timedelta(days=duration)
     if duration in mapping:
         return timedelta(days=mapping[duration])
     if duration.endswith("_days") and duration[:-5].isdigit():

--- a/mybot/keyboards/admin_vip_config_kb.py
+++ b/mybot/keyboards/admin_vip_config_kb.py
@@ -4,6 +4,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_admin_vip_config_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="📄 Tarifas", callback_data="config_tarifas")
+    builder.button(text="✉️ Configurar Mensajes", callback_data="vip_config_messages")
     builder.button(text="🔙 Volver", callback_data="admin_vip")
     builder.adjust(1)
     return builder.as_markup()
@@ -13,5 +14,14 @@ def get_tariff_select_kb(tariffs):
     builder = InlineKeyboardBuilder()
     for tariff in tariffs:
         builder.button(text=tariff.name, callback_data=f"generate_token_{tariff.id}")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_vip_messages_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📣 Mensaje de recordatorio", callback_data="edit_vip_reminder")
+    builder.button(text="👋 Mensaje de despedida", callback_data="edit_vip_farewell")
+    builder.button(text="🔙 Volver", callback_data="vip_config")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -62,6 +62,13 @@ class AdminConfigStates(StatesGroup):
     waiting_for_reaction_buttons = State()
 
 
+class AdminVipMessageStates(StatesGroup):
+    """States for configuring VIP channel messages."""
+
+    waiting_for_reminder_message = State()
+    waiting_for_farewell_message = State()
+
+
 class AdminMissionStates(StatesGroup):
     """States for creating missions from the admin panel."""
 


### PR DESCRIPTION
## Summary
- handle integer durations when redeeming tokens
- make VIP reminder and farewell messages configurable
- add admin flows for editing VIP messages

## Testing
- `python -m py_compile mybot/handlers/admin/vip_menu.py mybot/handlers/subscriptions.py mybot/keyboards/admin_vip_config_kb.py mybot/services/scheduler.py mybot/utils/admin_state.py`

------
https://chatgpt.com/codex/tasks/task_e_6850338ba988832987a0061dd1f7b138