### PR TITLE
Fix VIP token menu navigation

### DIFF
--- a/mybot/keyboards/admin_vip_config_kb.py
+++ b/mybot/keyboards/admin_vip_config_kb.py
@@ -13,5 +13,6 @@ def get_tariff_select_kb(tariffs):
     builder = InlineKeyboardBuilder()
     for tariff in tariffs:
         builder.button(text=tariff.name, callback_data=f"generate_token_{tariff.id}")
+    builder.button(text="🔙 Volver", callback_data="admin_vip")
     builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- add a back button when choosing a tariff for VIP token creation

## Testing
- `python -m py_compile mybot/keyboards/admin_vip_config_kb.py`


------
https://chatgpt.com/codex/tasks/task_e_685034bbd2f4832986cd03d5156375c2