### PR TITLE
Add centralized admin statistics

### DIFF
--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -3,7 +3,7 @@ from .level_service import LevelService
 from .mission_service import MissionService
 from .point_service import PointService
 from .reward_service import RewardService
-from .subscription_service import SubscriptionService
+from .subscription_service import SubscriptionService, get_admin_statistics
 from .token_service import TokenService, validate_token
 from .config_service import ConfigService
 from .plan_service import SubscriptionPlanService
@@ -17,6 +17,7 @@ __all__ = [
     "PointService",
     "RewardService",
     "SubscriptionService",
+    "get_admin_statistics",
     "TokenService",
     "validate_token",
     "ConfigService",


### PR DESCRIPTION
## Summary
- centralize admin stats in new `get_admin_statistics` function
- show Markdown-formatted VIP statistics with back button
- list active VIP subscribers with validated username display

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68504031b4688329acaff53d6276b545