### PR TITLE
Fix UTF-8 issues by sanitizing text inputs

### DIFF
--- a/old_gamificacion/handlers/user_handlers.py
+++ b/old_gamificacion/handlers/user_handlers.py
@@ -2,7 +2,12 @@ from aiogram import Router, F, Bot
 from aiogram.types import Message, CallbackQuery
 from aiogram.filters import CommandStart, Command
 from aiogram.fsm.context import FSMContext
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton, ReplyKeyboardMarkup, KeyboardButton
+from aiogram.types import (
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from database.models import User, Mission, Reward, get_user_menu_state, set_user_menu_state
@@ -18,8 +23,14 @@ from utils.keyboard_utils import (
     get_root_menu, get_parent_menu, get_child_menu,  # <--- Estas fueron añadidas/confirmadas
     get_main_reply_keyboard  # <--- Asegúrate de que esta esté aquí también
 )
-from utils.message_utils import get_profile_message, get_mission_details_message, get_reward_details_message, get_ranking_message # Añadido get_ranking_message
+from utils.message_utils import (
+    get_profile_message,
+    get_mission_details_message,
+    get_reward_details_message,
+    get_ranking_message,  # Añadido get_ranking_message
+)
 from utils.messages import BOT_MESSAGES # <--- Asegúrate de que esta esté importada
+from utils.text_utils import sanitize_text
 
 from config import Config
 import asyncio
@@ -33,9 +44,9 @@ router = Router()
 async def _handle_start_flow(message: Message, session: AsyncSession, bot: Bot) -> None:
     """Common logic for /start handling once user is identified."""
     user_id = message.from_user.id
-    username = message.from_user.username
-    first_name = message.from_user.first_name
-    last_name = message.from_user.last_name
+    username = sanitize_text(message.from_user.username)
+    first_name = sanitize_text(message.from_user.first_name)
+    last_name = sanitize_text(message.from_user.last_name)
 
     user = await session.get(User, user_id)
     is_new_user = False

--- a/old_gamificacion/services/mission_service.py
+++ b/old_gamificacion/services/mission_service.py
@@ -4,6 +4,7 @@ import random
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update
 from database.models import Mission, User
+from utils.text_utils import sanitize_text
 import logging
 
 logger = logging.getLogger(__name__)
@@ -123,16 +124,18 @@ class MissionService:
         return True, mission
 
     async def create_mission(self, name: str, description: str, points_reward: int, mission_type: str, requires_action: bool = False, action_data: dict = None) -> Mission:
-        mission_id = f"{mission_type}_{name.lower().replace(' ', '_').replace('.', '').replace(',', '')}" # Simple ID generation
+        mission_id = (
+            f"{mission_type}_{sanitize_text(name).lower().replace(' ', '_').replace('.', '').replace(',', '')}"
+        )  # Simple ID generation
         new_mission = Mission(
             id=mission_id,
-            name=name,
-            description=description,
+            name=sanitize_text(name),
+            description=sanitize_text(description),
             points_reward=points_reward,
             type=mission_type,
             is_active=True,
             requires_action=requires_action,
-            action_data=action_data
+            action_data=action_data,
         )
         self.session.add(new_mission)
         await self.session.commit()

--- a/old_gamificacion/services/reward_service.py
+++ b/old_gamificacion/services/reward_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from database.models import Reward, User
+from utils.text_utils import sanitize_text
 import logging
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,12 @@ class RewardService:
         return True, "Compra exitosa. ¡Disfruta tu recompensa!"
 
     async def create_reward(self, name: str, description: str, cost: int, stock: int = -1) -> Reward:
-        new_reward = Reward(name=name, description=description, cost=cost, stock=stock)
+        new_reward = Reward(
+            name=sanitize_text(name),
+            description=sanitize_text(description),
+            cost=cost,
+            stock=stock,
+        )
         self.session.add(new_reward)
         await self.session.commit()
         await self.session.refresh(new_reward)

--- a/old_gamificacion/utils/__init__.py
+++ b/old_gamificacion/utils/__init__.py
@@ -1,0 +1,1 @@
+from .text_utils import sanitize_text

--- a/old_gamificacion/utils/text_utils.py
+++ b/old_gamificacion/utils/text_utils.py
@@ -1,0 +1,5 @@
+def sanitize_text(value: str | None) -> str | None:
+    """Remove characters that cannot be encoded in UTF-8."""
+    if value is None:
+        return None
+    return value.encode("utf-8", "ignore").decode("utf-8", "ignore")


### PR DESCRIPTION
## Summary
- create a sanitize_text helper for the old gamification code
- sanitize username and name fields before storing
- sanitize text for mission and reward creation

## Testing
- `flake8` *(fails: E501 line too long and other style errors)*

------
https://chatgpt.com/codex/tasks/task_e_685051bf43f08329b2b33e9d20462dc9