### PR TITLE
Make free channel configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
    export BOT_TOKEN="<your_bot_token>"
    export ADMIN_IDS="11111;22222"       # user IDs with admin privileges
    export VIP_CHANNEL_ID="-100123456789"  # ID of the VIP Telegram channel
+   export FREE_CHANNEL_ID="-100987654321" # ID of the free Telegram channel
    export VIP_IDS="33333;44444"        # optional list of VIP user IDs
    ```
 

--- a/mybot/handlers/channel_access.py
+++ b/mybot/handlers/channel_access.py
@@ -5,10 +5,12 @@ from sqlalchemy import select
 from datetime import datetime
 
 from database.models import PendingChannelRequest, BotConfig
+from utils.config import FREE_CHANNEL_ID as CONFIG_FREE_CHANNEL_ID
 
 router = Router()
 
-FREE_CHANNEL_ID = -100123456789  # TODO: replace with real channel id
+# Channel ID used to handle join requests for the free channel.
+FREE_CHANNEL_ID = CONFIG_FREE_CHANNEL_ID
 
 
 @router.chat_join_request()

--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -33,9 +33,14 @@ VIP_IDS: List[int] = [
 # of ``0`` disables VIP checks and treats all users as non‑VIP.
 VIP_CHANNEL_ID = int(os.environ.get("VIP_CHANNEL_ID", "0"))
 
+# ID of the free Telegram channel used for basic access. A value of ``0``
+# disables handling of free channel join requests.
+FREE_CHANNEL_ID = int(os.environ.get("FREE_CHANNEL_ID", "0"))
+
 class Config:
     BOT_TOKEN = BOT_TOKEN
     ADMIN_ID = ADMIN_IDS[0] if ADMIN_IDS else 0
     CHANNEL_ID = VIP_CHANNEL_ID
+    FREE_CHANNEL_ID = FREE_CHANNEL_ID
     VIP_IDS = VIP_IDS
     DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///gamification.db")


### PR DESCRIPTION
## Summary
- add `FREE_CHANNEL_ID` environment variable in config utils
- read free channel id from config in the channel access handler
- document free channel variable in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68504eda8d808329a28984a395b2bf82