### PR TITLE
Fix encoding errors by sanitizing stored text

### DIFF
--- a/mybot/handlers/admin/subscription_plans.py
+++ b/mybot/handlers/admin/subscription_plans.py
@@ -10,6 +10,7 @@ from utils.admin_state import AdminTariffStates
 from keyboards.tarifas_kb import get_duration_kb, get_tarifas_kb
 from keyboards.common import get_back_kb
 from database.models import Tariff
+from utils.text_utils import sanitize_text
 
 router = Router()
 
@@ -77,7 +78,7 @@ async def tariff_name(message: Message, state: FSMContext, session: AsyncSession
         return
     data = await state.get_data()
     tariff = Tariff(
-        name=message.text,
+        name=sanitize_text(message.text),
         duration_days=data["duration_days"],
         price=data["price"],
     )

--- a/mybot/services/config_service.py
+++ b/mybot/services/config_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import ConfigEntry
+from utils.text_utils import sanitize_text
 
 
 class ConfigService:
@@ -14,11 +15,13 @@ class ConfigService:
         return entry.value if entry else None
 
     async def set_value(self, key: str, value: str) -> ConfigEntry:
+        """Store a configuration value, sanitizing text to avoid encoding issues."""
+        clean_value = sanitize_text(value)
         entry = await self.session.get(ConfigEntry, key)
         if entry:
-            entry.value = value
+            entry.value = clean_value
         else:
-            entry = ConfigEntry(key=key, value=value)
+            entry = ConfigEntry(key=key, value=clean_value)
             self.session.add(entry)
         await self.session.commit()
         await self.session.refresh(entry)

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -9,6 +9,7 @@ from database.models import (
     Challenge,
     UserChallengeProgress,
 )
+from utils.text_utils import sanitize_text
 import logging
 
 logger = logging.getLogger(__name__)
@@ -130,11 +131,11 @@ class MissionService:
         return True, mission
 
     async def create_mission(self, name: str, description: str, points_reward: int, mission_type: str, requires_action: bool = False, action_data: dict = None) -> Mission:
-        mission_id = f"{mission_type}_{name.lower().replace(' ', '_').replace('.', '').replace(',', '')}" # Simple ID generation
+        mission_id = f"{mission_type}_{sanitize_text(name).lower().replace(' ', '_').replace('.', '').replace(',', '')}"
         new_mission = Mission(
             id=mission_id,
-            name=name,
-            description=description,
+            name=sanitize_text(name),
+            description=sanitize_text(description),
             points_reward=points_reward,
             type=mission_type,
             is_active=True,


### PR DESCRIPTION
## Summary
- sanitize config values before saving
- clean mission names and descriptions
- ensure tariff names are sanitized

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850569156dc8329a3b67cfb7cb3da07