### PR TITLE
Fix start command flow

### DIFF
--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -11,6 +11,7 @@ from keyboards.subscription_kb import get_subscription_kb
 from utils.user_roles import is_admin, is_vip_member
 from utils.keyboard_utils import get_main_menu_keyboard
 from utils.messages import BOT_MESSAGES
+from utils.menu_utils import send_menu
 
 router = Router()
 
@@ -32,9 +33,13 @@ async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
         await session.commit()
 
     if is_admin(user_id):
-        await message.answer(
-            "Bienvenido, administrador!",
-            reply_markup=get_admin_main_kb(),
+        # Show the admin main menu directly when an administrator runs /start
+        await send_menu(
+            message,
+            "Men\u00fa de administraci\u00f3n",
+            get_admin_main_kb(),
+            session,
+            "admin_main",
         )
     elif await is_vip_member(bot, user_id):
         await message.answer(

--- a/mybot/middlewares/points_middleware.py
+++ b/mybot/middlewares/points_middleware.py
@@ -27,6 +27,11 @@ class PointsMiddleware(BaseMiddleware):
         try:
             if isinstance(event, Message):
                 if event.from_user and not event.from_user.is_bot:
+                    # Ignore bot commands so /start and similar messages don't
+                    # grant points and trigger notifications
+                    if event.text and event.text.startswith("/"):
+                        return await handler(event, data)
+
                     await service.award_message(event.from_user.id, bot)
                     completed = await mission_service.increment_challenge_progress(
                         event.from_user.id,


### PR DESCRIPTION
## Summary
- avoid awarding points on command messages in `PointsMiddleware`
- show admin menu directly from the main `/start` handler

## Testing
- `python -m py_compile mybot/middlewares/points_middleware.py mybot/handlers/start.py`

------
https://chatgpt.com/codex/tasks/task_e_68505b373040832980b1b4213435597d