### PR TITLE
Implement event and raffle admin management

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -90,6 +90,25 @@ class Event(AsyncAttrs, Base):
     created_at = Column(DateTime, default=func.now())
 
 
+class Raffle(AsyncAttrs, Base):
+    __tablename__ = "raffles"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    description = Column(Text)
+    prize = Column(String, nullable=True)
+    winner_id = Column(BigInteger, nullable=True)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+    ended_at = Column(DateTime, nullable=True)
+
+
+class RaffleEntry(AsyncAttrs, Base):
+    __tablename__ = "raffle_entries"
+    raffle_id = Column(Integer, ForeignKey("raffles.id"), primary_key=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"), primary_key=True)
+    created_at = Column(DateTime, default=func.now())
+
+
 class Level(AsyncAttrs, Base):
     __tablename__ = "levels"
 

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -5,6 +5,7 @@ from .config_menu import router as config_router
 from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
+from .event_admin import router as event_admin_router
 
 __all__ = [
     "admin_router",
@@ -14,4 +15,5 @@ __all__ = [
     "channel_admin_router",
     "subscription_plans_router",
     "game_admin_router",
+    "event_admin_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -26,6 +26,7 @@ from .config_menu import router as config_router
 from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router, show_users_page
+from .event_admin import router as event_admin_router
 
 router = Router()
 router.include_router(vip_router)
@@ -34,6 +35,7 @@ router.include_router(config_router)
 router.include_router(channel_admin_router)
 router.include_router(subscription_plans_router)
 router.include_router(game_admin_router)
+router.include_router(event_admin_router)
 
 
 @router.message(Command("admin_generate_token"))
@@ -122,18 +124,6 @@ async def admin_manage_content(callback: CallbackQuery, session: AsyncSession):
     await callback.answer()
 
 
-@router.callback_query(F.data == "admin_manage_events_sorteos")
-async def admin_manage_events(callback: CallbackQuery, session: AsyncSession):
-    if not is_admin(callback.from_user.id):
-        return await callback.answer()
-    await update_menu(
-        callback,
-        "Gesti\u00f3n de eventos y sorteos en desarrollo.",
-        get_back_kb("admin_main_menu"),
-        session,
-        "admin_manage_events_sorteos",
-    )
-    await callback.answer()
 
 
 @router.callback_query(F.data == "admin_bot_config")
@@ -174,7 +164,6 @@ IGNORED_CALLBACKS = {
     "admin_back",
     "admin_manage_users",
     "admin_manage_content",
-    "admin_manage_events_sorteos",
     "admin_bot_config",
     "admin_main_menu",
 }

--- a/mybot/handlers/admin/event_admin.py
+++ b/mybot/handlers/admin/event_admin.py
@@ -1,0 +1,263 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from utils.user_roles import is_admin
+from utils.menu_utils import update_menu
+from keyboards.admin_event_kb import (
+    get_admin_event_main_kb,
+    get_event_menu_kb,
+    get_raffle_menu_kb,
+)
+from keyboards.common import get_back_kb
+from utils.admin_state import AdminEventStates, AdminRaffleStates
+from services import EventService, RaffleService
+
+router = Router()
+
+
+@router.callback_query(F.data == "admin_manage_events_sorteos")
+async def admin_events_main(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await update_menu(
+        callback,
+        "Gestionar Eventos y Sorteos",
+        get_admin_event_main_kb(),
+        session,
+        "admin_manage_events_sorteos",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "event_menu")
+async def event_menu(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await update_menu(
+        callback,
+        "Menú de Eventos",
+        get_event_menu_kb(),
+        session,
+        "event_menu",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "raffle_menu")
+async def raffle_menu(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await update_menu(
+        callback,
+        "Menú de Sorteos",
+        get_raffle_menu_kb(),
+        session,
+        "raffle_menu",
+    )
+    await callback.answer()
+
+
+# ----- Event creation flow -----
+
+@router.callback_query(F.data == "create_event")
+async def start_create_event(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Nombre del evento:", reply_markup=get_back_kb("event_menu")
+    )
+    await state.set_state(AdminEventStates.creating_event_name)
+    await callback.answer()
+
+
+@router.message(AdminEventStates.creating_event_name)
+async def process_event_name(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(name=message.text)
+    await message.answer("Descripción del evento:")
+    await state.set_state(AdminEventStates.creating_event_description)
+
+
+@router.message(AdminEventStates.creating_event_description)
+async def process_event_description(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(description=message.text)
+    await message.answer("Multiplicador de puntos (ej. 2 para doble):")
+    await state.set_state(AdminEventStates.creating_event_multiplier)
+
+
+@router.message(AdminEventStates.creating_event_multiplier)
+async def finish_event_create(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    try:
+        multiplier = int(message.text)
+    except ValueError:
+        await message.answer("Ingresa un número válido:")
+        return
+    data = await state.get_data()
+    service = EventService(session)
+    await service.create_event(data["name"], data["description"], multiplier)
+    await message.answer(
+        "Evento creado.", reply_markup=get_event_menu_kb()
+    )
+    await state.clear()
+
+
+# ----- List events -----
+
+@router.callback_query(F.data == "list_events")
+async def list_events(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    service = EventService(session)
+    events = await service.list_active_events()
+    if events:
+        lines = [f"{e.id}. {e.name} x{e.multiplier}" for e in events]
+        text = "Eventos activos:\n" + "\n".join(lines)
+    else:
+        text = "No hay eventos activos."
+    await callback.message.edit_text(text, reply_markup=get_back_kb("event_menu"))
+    await callback.answer()
+
+
+# ----- End event -----
+
+@router.callback_query(F.data == "end_event")
+async def choose_event_end(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    service = EventService(session)
+    events = await service.list_active_events()
+    if not events:
+        await callback.answer("No hay eventos activos", show_alert=True)
+        return
+    from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+    builder = InlineKeyboardBuilder()
+    for ev in events:
+        builder.button(text=ev.name, callback_data=f"end_event_{ev.id}")
+    builder.button(text="🔙 Volver", callback_data="event_menu")
+    builder.adjust(1)
+    await callback.message.edit_text(
+        "Selecciona el evento a finalizar:", reply_markup=builder.as_markup()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("end_event_"))
+async def finish_event(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    event_id = int(callback.data.split("_")[-1])
+    service = EventService(session)
+    await service.end_event(event_id)
+    await callback.message.edit_text(
+        "Evento finalizado.", reply_markup=get_event_menu_kb()
+    )
+    await callback.answer()
+
+
+# ----- Raffle creation flow -----
+
+@router.callback_query(F.data == "create_raffle")
+async def start_create_raffle(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Nombre del sorteo:", reply_markup=get_back_kb("raffle_menu")
+    )
+    await state.set_state(AdminRaffleStates.creating_raffle_name)
+    await callback.answer()
+
+
+@router.message(AdminRaffleStates.creating_raffle_name)
+async def raffle_name(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(name=message.text)
+    await message.answer("Descripción del sorteo:")
+    await state.set_state(AdminRaffleStates.creating_raffle_description)
+
+
+@router.message(AdminRaffleStates.creating_raffle_description)
+async def raffle_desc(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(description=message.text)
+    await message.answer("Premio del sorteo:")
+    await state.set_state(AdminRaffleStates.creating_raffle_prize)
+
+
+@router.message(AdminRaffleStates.creating_raffle_prize)
+async def raffle_finish(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    service = RaffleService(session)
+    await service.create_raffle(data["name"], data["description"], message.text)
+    await message.answer(
+        "Sorteo creado.", reply_markup=get_raffle_menu_kb()
+    )
+    await state.clear()
+
+
+# ----- List raffles -----
+
+@router.callback_query(F.data == "list_raffles")
+async def list_raffles(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    service = RaffleService(session)
+    raffles = await service.list_active_raffles()
+    if raffles:
+        lines = [f"{r.id}. {r.name} - premio {r.prize}" for r in raffles]
+        text = "Sorteos activos:\n" + "\n".join(lines)
+    else:
+        text = "No hay sorteos activos."
+    await callback.message.edit_text(text, reply_markup=get_back_kb("raffle_menu"))
+    await callback.answer()
+
+
+# ----- End raffle -----
+
+@router.callback_query(F.data == "end_raffle")
+async def choose_raffle_end(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    service = RaffleService(session)
+    raffles = await service.list_active_raffles()
+    if not raffles:
+        await callback.answer("No hay sorteos activos", show_alert=True)
+        return
+    from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+    builder = InlineKeyboardBuilder()
+    for r in raffles:
+        builder.button(text=r.name, callback_data=f"end_raffle_{r.id}")
+    builder.button(text="🔙 Volver", callback_data="raffle_menu")
+    builder.adjust(1)
+    await callback.message.edit_text(
+        "Selecciona el sorteo a finalizar:", reply_markup=builder.as_markup()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("end_raffle_"))
+async def finish_raffle(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    raffle_id = int(callback.data.split("_")[-1])
+    service = RaffleService(session)
+    raffle = await service.end_raffle(raffle_id)
+    if raffle and raffle.winner_id:
+        msg = f"Sorteo finalizado. Ganador ID {raffle.winner_id}"
+    else:
+        msg = "Sorteo finalizado. Sin participantes."
+    await callback.message.edit_text(msg, reply_markup=get_raffle_menu_kb())
+    await callback.answer()

--- a/mybot/keyboards/admin_event_kb.py
+++ b/mybot/keyboards/admin_event_kb.py
@@ -1,0 +1,30 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_event_main_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="⚡ Eventos", callback_data="event_menu")
+    builder.button(text="🎟 Sorteos", callback_data="raffle_menu")
+    builder.button(text="🔙 Volver", callback_data="admin_main_menu")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_event_menu_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="➕ Crear Evento", callback_data="create_event")
+    builder.button(text="📃 Eventos Activos", callback_data="list_events")
+    builder.button(text="⛔ Finalizar Evento", callback_data="end_event")
+    builder.button(text="🔙 Volver", callback_data="admin_manage_events_sorteos")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_raffle_menu_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="➕ Crear Sorteo", callback_data="create_raffle")
+    builder.button(text="📃 Sorteos Activos", callback_data="list_raffles")
+    builder.button(text="🏁 Finalizar Sorteo", callback_data="end_raffle")
+    builder.button(text="🔙 Volver", callback_data="admin_manage_events_sorteos")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -8,6 +8,8 @@ from .token_service import TokenService, validate_token
 from .config_service import ConfigService
 from .plan_service import SubscriptionPlanService
 from .channel_service import ChannelService
+from .event_service import EventService
+from .raffle_service import RaffleService
 from .scheduler import channel_request_scheduler, vip_subscription_scheduler
 
 __all__ = [
@@ -25,4 +27,6 @@ __all__ = [
     "ChannelService",
     "channel_request_scheduler",
     "vip_subscription_scheduler",
+    "EventService",
+    "RaffleService",
 ]

--- a/mybot/services/event_service.py
+++ b/mybot/services/event_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import datetime
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from database.models import Event
+
+
+class EventService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create_event(self, name: str, description: str, multiplier: int) -> Event:
+        event = Event(
+            name=name,
+            description=description,
+            multiplier=multiplier,
+            is_active=True,
+            start_time=datetime.datetime.utcnow(),
+        )
+        self.session.add(event)
+        await self.session.commit()
+        await self.session.refresh(event)
+        return event
+
+    async def list_active_events(self) -> list[Event]:
+        stmt = select(Event).where(Event.is_active == True)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def list_events(self) -> list[Event]:
+        stmt = select(Event)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def end_event(self, event_id: int) -> Event | None:
+        event = await self.session.get(Event, event_id)
+        if event and event.is_active:
+            event.is_active = False
+            event.end_time = datetime.datetime.utcnow()
+            await self.session.commit()
+            await self.session.refresh(event)
+        return event
+
+    async def get_multiplier(self) -> int:
+        events = await self.list_active_events()
+        mult = 1
+        for ev in events:
+            try:
+                mult *= int(ev.multiplier)
+            except Exception:
+                pass
+        return mult

--- a/mybot/services/point_service.py
+++ b/mybot/services/point_service.py
@@ -5,6 +5,7 @@ from utils.user_roles import get_points_multiplier
 from aiogram import Bot
 from services.level_service import LevelService
 from services.achievement_service import AchievementService
+from services.event_service import EventService
 import datetime
 import logging
 
@@ -80,6 +81,8 @@ class PointService:
         multiplier = 1
         if bot:
             multiplier = await get_points_multiplier(bot, user_id)
+            event_mult = await EventService(self.session).get_multiplier()
+            multiplier *= event_mult
 
         total = points * multiplier
         user.points += total

--- a/mybot/services/raffle_service.py
+++ b/mybot/services/raffle_service.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import datetime
+import random
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from database.models import Raffle, RaffleEntry
+
+
+class RaffleService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create_raffle(self, name: str, description: str, prize: str) -> Raffle:
+        raffle = Raffle(
+            name=name,
+            description=description,
+            prize=prize,
+            is_active=True,
+            created_at=datetime.datetime.utcnow(),
+        )
+        self.session.add(raffle)
+        await self.session.commit()
+        await self.session.refresh(raffle)
+        return raffle
+
+    async def add_entry(self, raffle_id: int, user_id: int) -> RaffleEntry:
+        entry = RaffleEntry(raffle_id=raffle_id, user_id=user_id)
+        self.session.add(entry)
+        await self.session.commit()
+        await self.session.refresh(entry)
+        return entry
+
+    async def list_active_raffles(self) -> list[Raffle]:
+        stmt = select(Raffle).where(Raffle.is_active == True)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def list_raffles(self) -> list[Raffle]:
+        stmt = select(Raffle)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def end_raffle(self, raffle_id: int) -> Raffle | None:
+        raffle = await self.session.get(Raffle, raffle_id)
+        if raffle and raffle.is_active:
+            stmt = select(RaffleEntry).where(RaffleEntry.raffle_id == raffle_id)
+            entries = (await self.session.execute(stmt)).scalars().all()
+            if entries:
+                winner = random.choice(entries)
+                raffle.winner_id = winner.user_id
+            raffle.is_active = False
+            raffle.ended_at = datetime.datetime.utcnow()
+            await self.session.commit()
+            await self.session.refresh(raffle)
+        return raffle
+
+    async def list_entries(self, raffle_id: int) -> list[RaffleEntry]:
+        stmt = select(RaffleEntry).where(RaffleEntry.raffle_id == raffle_id)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -78,3 +78,15 @@ class AdminMissionStates(StatesGroup):
     creating_mission_type = State()
     creating_mission_requires_action = State()
     creating_mission_action_data = State()
+
+
+class AdminEventStates(StatesGroup):
+    creating_event_name = State()
+    creating_event_description = State()
+    creating_event_multiplier = State()
+
+
+class AdminRaffleStates(StatesGroup):
+    creating_raffle_name = State()
+    creating_raffle_description = State()
+    creating_raffle_prize = State()


### PR DESCRIPTION
## Summary
- add data models for `Raffle` and `RaffleEntry`
- expose new services `EventService` and `RaffleService`
- implement admin handlers for creating and managing events and raffles
- add keyboards for the new admin menus
- apply event multipliers when awarding points

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68505bbf97948329865f424df013037f