### PR TITLE
Add DB init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,12 @@
 | `DATABASE_URL` | SQLAlchemy database URL. Defaults to `sqlite+aiosqlite:///gamification.db` |
 | `VIP_POINTS_MULTIPLIER` | Points multiplier applied when a VIP user earns points |
 
-3. (Optional) Seed default achievements. This only needs to be done once per
-   database and can be triggered with a small helper script:
+3. Initialise the database and populate base data (tables, achievements,
+   levels and some starter missions). Run this command once after configuring
+   the environment:
 
    ```bash
-   python - <<'EOF'
-   import asyncio
-   from mybot.database.setup import init_db, get_session
-   from mybot.services.achievement_service import AchievementService
-
-   async def main():
-       await init_db()
-       Session = await get_session()
-       async with Session() as s:
-           await AchievementService(s).ensure_achievements_exist()
-
-   asyncio.run(main())
-   EOF
+   python scripts/init_db.py
    ```
 
 4. Run the bot locally:

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from mybot.database.setup import init_db, get_session
+from mybot.services.achievement_service import AchievementService
+from mybot.services.level_service import LevelService
+from mybot.services.mission_service import MissionService
+
+DEFAULT_MISSIONS = [
+    {
+        "name": "Daily Check-in",
+        "description": "Registra tu actividad diaria con /checkin",
+        "points_reward": 10,
+        "mission_type": "daily",
+        "requires_action": False,
+        "action_data": None,
+    },
+    {
+        "name": "Primer Mensaje",
+        "description": "Envía tu primer mensaje en el chat",
+        "points_reward": 5,
+        "mission_type": "one_time",
+        "requires_action": False,
+        "action_data": None,
+    },
+]
+
+async def main() -> None:
+    await init_db()
+    Session = await get_session()
+    async with Session() as session:
+        await AchievementService(session).ensure_achievements_exist()
+        level_service = LevelService(session)
+        await level_service._init_levels()
+
+        mission_service = MissionService(session)
+        existing = await mission_service.get_active_missions()
+        if not existing:
+            for m in DEFAULT_MISSIONS:
+                await mission_service.create_mission(
+                    m["name"],
+                    m["description"],
+                    m["points_reward"],
+                    m["mission_type"],
+                    m["requires_action"],
+                    m["action_data"],
+                )
+    print("Database initialised")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `scripts/init_db.py` to create tables and seed base data
- document database initialisation in README

## Testing
- `python -m py_compile scripts/init_db.py`

------
https://chatgpt.com/codex/tasks/task_e_685064f9fc648329a45e810a2b647778