### PR TITLE
Add back button for token generation

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -61,7 +61,9 @@ async def generate_token_callback(callback: CallbackQuery, session: AsyncSession
     await session.commit()
     bot_username = (await bot.get_me()).username
     link = f"https://t.me/{bot_username}?start={token_string}"
-    await callback.message.edit_text(f"Enlace generado: {link}")
+    await callback.message.edit_text(
+        f"Enlace generado: {link}", reply_markup=get_back_kb("admin_vip")
+    )
     await callback.answer()
 
 


### PR DESCRIPTION
## Summary
- add back button after generating a token so admins can return to the VIP menu

## Testing
- `python -m compileall -q mybot`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850663ed2388329a0972f1cc6465f7c