### PR TITLE
Improve scheduler reliability and admin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
    export VIP_IDS="33333;44444"           # optional list of VIP user IDs
    export DATABASE_URL="sqlite+aiosqlite:///gamification.db"  # DB connection
    export VIP_POINTS_MULTIPLIER="2"       # points multiplier for VIP members
+   export CHANNEL_SCHEDULER_INTERVAL="30" # seconds between channel checks
+   export VIP_SCHEDULER_INTERVAL="3600"   # seconds between VIP checks
    ```
 
    `DATABASE_URL` defaults to a local SQLite database. When running for the
@@ -35,6 +37,8 @@
 | `VIP_IDS` | Extra user IDs treated as VIP regardless of channel membership |
 | `DATABASE_URL` | SQLAlchemy database URL. Defaults to `sqlite+aiosqlite:///gamification.db` |
 | `VIP_POINTS_MULTIPLIER` | Points multiplier applied when a VIP user earns points |
+| `CHANNEL_SCHEDULER_INTERVAL` | Seconds between checks for channel requests. Defaults to `30` |
+| `VIP_SCHEDULER_INTERVAL` | Seconds between VIP subscription checks. Defaults to `3600` |
 
 3. Initialise the database and populate base data (tables, achievements,
    levels and some starter missions). Run this command once after configuring
@@ -82,6 +86,9 @@ Two background loops run when the bot starts:
    approves them after the wait time stored in the `bot_config` table.
 2. **VIP subscription monitor** – sends expiry reminders 24&nbsp;hours before a
    VIP subscription ends and removes expired users from the VIP channel.
+   The frequency of these checks can be changed at runtime from the admin
+   panel or by setting `CHANNEL_SCHEDULER_INTERVAL` and
+   `VIP_SCHEDULER_INTERVAL` environment variables.
 
 ## Project structure
 

--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -64,9 +64,12 @@ async def main() -> None:
     pending_task = asyncio.create_task(channel_request_scheduler(bot, Session))
     vip_task = asyncio.create_task(vip_subscription_scheduler(bot, Session))
 
-    await dp.start_polling(bot)
-    pending_task.cancel()
-    vip_task.cancel()
+    try:
+        await dp.start_polling(bot)
+    finally:
+        pending_task.cancel()
+        vip_task.cancel()
+        await asyncio.gather(pending_task, vip_task, return_exceptions=True)
 
 
 if __name__ == "__main__":

--- a/mybot/handlers/admin.py
+++ b/mybot/handlers/admin.py
@@ -1,9 +1,12 @@
 from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery
+from aiogram import Bot
 from aiogram.filters import Command
 
 from keyboards.admin_kb import get_admin_kb
 from utils.user_roles import is_admin
+from services.scheduler import run_channel_request_check, run_vip_subscription_check
+from database.setup import get_session
 
 router = Router()
 
@@ -18,3 +21,14 @@ async def admin_menu(message: Message):
 @router.callback_query(F.data == "admin_button")
 async def admin_placeholder_handler(callback: CallbackQuery):
     await callback.answer("Acción de administración")
+
+
+@router.message(Command("run_schedulers"))
+async def run_schedulers(message: Message, bot: Bot):
+    """Allow an admin to trigger scheduler checks manually."""
+    if not is_admin(message.from_user.id):
+        return
+    Session = await get_session()
+    await run_channel_request_check(bot, Session)
+    await run_vip_subscription_check(bot, Session)
+    await message.answer("Schedulers ejecutados")

--- a/mybot/handlers/admin/config_menu.py
+++ b/mybot/handlers/admin/config_menu.py
@@ -1,11 +1,14 @@
 from aiogram import Router, F
 from aiogram.types import CallbackQuery, Message
+from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
 from utils.user_roles import is_admin
 from utils.menu_utils import update_menu
-from keyboards.admin_config_kb import get_admin_config_kb
+from keyboards.admin_config_kb import get_admin_config_kb, get_scheduler_config_kb
 from utils.keyboard_utils import get_back_keyboard
 from services.config_service import ConfigService
+from services.scheduler import run_channel_request_check, run_vip_subscription_check
+from database.setup import get_session
 from utils.admin_state import AdminConfigStates
 from aiogram.fsm.context import FSMContext
 
@@ -50,4 +53,78 @@ async def set_reaction_buttons(message: Message, state: FSMContext, session: Asy
     service = ConfigService(session)
     await service.set_value("reaction_buttons", ";".join(texts))
     await message.answer("Botones de reacción actualizados.", reply_markup=get_admin_config_kb())
+    await state.clear()
+
+
+@router.callback_query(F.data == "config_scheduler")
+async def scheduler_menu(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    config = ConfigService(session)
+    ch = await config.get_value("channel_scheduler_interval") or "30"
+    vip = await config.get_value("vip_scheduler_interval") or "3600"
+    text = f"Intervalos actuales:\nCanal: {ch}s\nVIP: {vip}s"
+    await update_menu(callback, text, get_scheduler_config_kb(), session, "scheduler_config")
+    await callback.answer()
+
+
+@router.callback_query(F.data == "set_channel_interval")
+async def prompt_channel_interval(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Ingresa el intervalo en segundos para revisar solicitudes de canal:",
+        reply_markup=get_back_keyboard("config_scheduler"),
+    )
+    await state.set_state(AdminConfigStates.waiting_for_channel_interval)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "set_vip_interval")
+async def prompt_vip_interval(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Ingresa el intervalo en segundos para revisar suscripciones VIP:",
+        reply_markup=get_back_keyboard("config_scheduler"),
+    )
+    await state.set_state(AdminConfigStates.waiting_for_vip_interval)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "run_schedulers_now")
+async def run_schedulers_now(callback: CallbackQuery, bot: Bot, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    Session = await get_session()
+    await run_channel_request_check(bot, Session)
+    await run_vip_subscription_check(bot, Session)
+    await callback.answer("Schedulers ejecutados", show_alert=True)
+
+
+@router.message(AdminConfigStates.waiting_for_channel_interval)
+async def set_channel_interval(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    try:
+        seconds = int(message.text.strip())
+    except ValueError:
+        await message.answer("Ingresa un número válido.")
+        return
+    await ConfigService(session).set_value("channel_scheduler_interval", str(seconds))
+    await message.answer("Intervalo actualizado.", reply_markup=get_admin_config_kb())
+    await state.clear()
+
+
+@router.message(AdminConfigStates.waiting_for_vip_interval)
+async def set_vip_interval(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    try:
+        seconds = int(message.text.strip())
+    except ValueError:
+        await message.answer("Ingresa un número válido.")
+        return
+    await ConfigService(session).set_value("vip_scheduler_interval", str(seconds))
+    await message.answer("Intervalo actualizado.", reply_markup=get_admin_config_kb())
     await state.clear()

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -4,6 +4,17 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_admin_config_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="📝 Configurar Reacciones", callback_data="config_reaction_buttons")
+    builder.button(text="⏱️ Schedulers", callback_data="config_scheduler")
     builder.button(text="🔙 Volver", callback_data="admin_back")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_scheduler_config_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="⏲ Intervalo Canal", callback_data="set_channel_interval")
+    builder.button(text="⏲ Intervalo VIP", callback_data="set_vip_interval")
+    builder.button(text="▶ Ejecutar Ahora", callback_data="run_schedulers_now")
+    builder.button(text="🔙 Volver", callback_data="admin_config")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/services/scheduler.py
+++ b/mybot/services/scheduler.py
@@ -1,79 +1,121 @@
 import asyncio
+import logging
 from datetime import datetime, timedelta
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
 from sqlalchemy import select
 
 from database.models import PendingChannelRequest, BotConfig, User
-from utils.config import VIP_CHANNEL_ID
+from utils.config import VIP_CHANNEL_ID, CHANNEL_SCHEDULER_INTERVAL, VIP_SCHEDULER_INTERVAL
 from services.config_service import ConfigService
 
 
+async def run_channel_request_check(bot: Bot, session_factory: async_sessionmaker[AsyncSession]):
+    """Process pending channel requests once."""
+    async with session_factory() as session:
+        config = await session.get(BotConfig, 1)
+        wait_minutes = config.free_channel_wait_time_minutes if config else 0
+        threshold = datetime.utcnow() - timedelta(minutes=wait_minutes)
+        stmt = select(PendingChannelRequest).where(
+            PendingChannelRequest.approved == False,
+            PendingChannelRequest.request_timestamp <= threshold,
+        )
+        result = await session.execute(stmt)
+        requests = result.scalars().all()
+        for req in requests:
+            try:
+                await bot.approve_chat_join_request(req.chat_id, req.user_id)
+                await bot.send_message(req.user_id, "Tu solicitud de acceso ha sido aprobada.")
+                await session.delete(req)
+                logging.info("Approved join request %s for %s", req.chat_id, req.user_id)
+            except Exception as e:
+                logging.exception("Failed to approve join request for %s: %s", req.user_id, e)
+        await session.commit()
+
+
 async def channel_request_scheduler(bot: Bot, session_factory: async_sessionmaker[AsyncSession]):
-    while True:
-        async with session_factory() as session:
-            config = await session.get(BotConfig, 1)
-            wait_minutes = config.free_channel_wait_time_minutes if config else 0
-            threshold = datetime.utcnow() - timedelta(minutes=wait_minutes)
-            stmt = select(PendingChannelRequest).where(
-                PendingChannelRequest.approved == False,
-                PendingChannelRequest.request_timestamp <= threshold,
-            )
-            result = await session.execute(stmt)
-            requests = result.scalars().all()
-            for req in requests:
-                try:
-                    await bot.approve_chat_join_request(req.chat_id, req.user_id)
-                    await bot.send_message(req.user_id, "Tu solicitud de acceso ha sido aprobada.")
-                    await session.delete(req)
-                except Exception:
-                    pass
-            await session.commit()
-        await asyncio.sleep(30)
+    """Background task processing channel join requests."""
+    logging.info("Channel request scheduler started")
+    interval = CHANNEL_SCHEDULER_INTERVAL
+    try:
+        while True:
+            await run_channel_request_check(bot, session_factory)
+            async with session_factory() as session:
+                config_service = ConfigService(session)
+                value = await config_service.get_value("channel_scheduler_interval")
+                if value and value.isdigit():
+                    interval = int(value)
+            await asyncio.sleep(interval)
+    except asyncio.CancelledError:
+        logging.info("Channel request scheduler cancelled")
+        raise
+    except Exception:
+        logging.exception("Unhandled error in channel request scheduler")
+
+
+async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmaker[AsyncSession]):
+    """Check VIP expirations and send reminders once."""
+    async with session_factory() as session:
+        now = datetime.utcnow()
+        remind_threshold = now + timedelta(hours=24)
+        config_service = ConfigService(session)
+        reminder_msg = await config_service.get_value("vip_reminder_message")
+        farewell_msg = await config_service.get_value("vip_farewell_message")
+        if not reminder_msg:
+            reminder_msg = "Tu suscripción VIP expira pronto."
+        if not farewell_msg:
+            farewell_msg = "Tu suscripción VIP ha expirado."
+        stmt = select(User).where(
+            User.role == "vip",
+            User.vip_expires_at <= remind_threshold,
+            User.vip_expires_at > now,
+            (User.last_reminder_sent_at.is_(None))
+            | (User.last_reminder_sent_at <= now - timedelta(hours=24)),
+        )
+        result = await session.execute(stmt)
+        users = result.scalars().all()
+        for user in users:
+            try:
+                await bot.send_message(user.id, reminder_msg)
+                user.last_reminder_sent_at = now
+                logging.info("Sent VIP expiry reminder to %s", user.id)
+            except Exception as e:
+                logging.exception("Failed to send reminder to %s: %s", user.id, e)
+
+        stmt = select(User).where(
+            User.role == "vip",
+            User.vip_expires_at.is_not(None),
+            User.vip_expires_at <= now,
+        )
+        result = await session.execute(stmt)
+        expired_users = result.scalars().all()
+        for user in expired_users:
+            try:
+                if VIP_CHANNEL_ID:
+                    await bot.kick_chat_member(VIP_CHANNEL_ID, user.id)
+            except Exception as e:
+                logging.exception("Failed to remove %s from VIP channel: %s", user.id, e)
+            user.role = "free"
+            await bot.send_message(user.id, farewell_msg)
+            logging.info("VIP expired for %s", user.id)
+        await session.commit()
 
 
 async def vip_subscription_scheduler(bot: Bot, session_factory: async_sessionmaker[AsyncSession]):
-    while True:
-        async with session_factory() as session:
-            now = datetime.utcnow()
-            remind_threshold = now + timedelta(hours=24)
-            config_service = ConfigService(session)
-            reminder_msg = await config_service.get_value("vip_reminder_message")
-            farewell_msg = await config_service.get_value("vip_farewell_message")
-            if not reminder_msg:
-                reminder_msg = "Tu suscripción VIP expira pronto."
-            if not farewell_msg:
-                farewell_msg = "Tu suscripción VIP ha expirado."
-            stmt = select(User).where(
-                User.role == "vip",
-                User.vip_expires_at <= remind_threshold,
-                User.vip_expires_at > now,
-                (User.last_reminder_sent_at.is_(None))
-                | (User.last_reminder_sent_at <= now - timedelta(hours=24)),
-            )
-            result = await session.execute(stmt)
-            users = result.scalars().all()
-            for user in users:
-                try:
-                    await bot.send_message(user.id, reminder_msg)
-                    user.last_reminder_sent_at = now
-                except Exception:
-                    pass
-
-            stmt = select(User).where(
-                User.role == "vip",
-                User.vip_expires_at.is_not(None),
-                User.vip_expires_at <= now,
-            )
-            result = await session.execute(stmt)
-            expired_users = result.scalars().all()
-            for user in expired_users:
-                try:
-                    if VIP_CHANNEL_ID:
-                        await bot.kick_chat_member(VIP_CHANNEL_ID, user.id)
-                except Exception:
-                    pass
-                user.role = "free"
-                await bot.send_message(user.id, farewell_msg)
-            await session.commit()
-        await asyncio.sleep(3600)
+    """Background task checking VIP subscriptions."""
+    logging.info("VIP subscription scheduler started")
+    interval = VIP_SCHEDULER_INTERVAL
+    try:
+        while True:
+            await run_vip_subscription_check(bot, session_factory)
+            async with session_factory() as session:
+                config_service = ConfigService(session)
+                value = await config_service.get_value("vip_scheduler_interval")
+                if value and value.isdigit():
+                    interval = int(value)
+            await asyncio.sleep(interval)
+    except asyncio.CancelledError:
+        logging.info("VIP subscription scheduler cancelled")
+        raise
+    except Exception:
+        logging.exception("Unhandled error in VIP subscription scheduler")

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -60,6 +60,8 @@ class AdminConfigStates(StatesGroup):
     """States for bot configuration options."""
 
     waiting_for_reaction_buttons = State()
+    waiting_for_channel_interval = State()
+    waiting_for_vip_interval = State()
 
 
 class AdminVipMessageStates(StatesGroup):

--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -37,6 +37,12 @@ VIP_CHANNEL_ID = int(os.environ.get("VIP_CHANNEL_ID", "0"))
 # disables handling of free channel join requests.
 FREE_CHANNEL_ID = int(os.environ.get("FREE_CHANNEL_ID", "0"))
 
+# Default scheduler intervals in seconds. These can be overridden via
+# environment variables and further adjusted at runtime using the admin
+# configuration menu.
+CHANNEL_SCHEDULER_INTERVAL = int(os.environ.get("CHANNEL_SCHEDULER_INTERVAL", "30"))
+VIP_SCHEDULER_INTERVAL = int(os.environ.get("VIP_SCHEDULER_INTERVAL", "3600"))
+
 class Config:
     BOT_TOKEN = BOT_TOKEN
     ADMIN_ID = ADMIN_IDS[0] if ADMIN_IDS else 0
@@ -44,3 +50,5 @@ class Config:
     FREE_CHANNEL_ID = FREE_CHANNEL_ID
     VIP_IDS = VIP_IDS
     DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///gamification.db")
+    CHANNEL_SCHEDULER_INTERVAL = CHANNEL_SCHEDULER_INTERVAL
+    VIP_SCHEDULER_INTERVAL = VIP_SCHEDULER_INTERVAL


### PR DESCRIPTION
## Summary
- allow configuring scheduler intervals via environment or admin panel
- add command and menu option for admins to run schedulers manually
- improve startup and shutdown of scheduler tasks with logging
- document new environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68506b6ee0848329b84aecfdb1201256