### PR TITLE
Implement admin channel configuration

### DIFF
--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -30,7 +30,6 @@ from services.mission_service import MissionService
 from database.models import User, Mission
 from services.point_service import PointService
 from services.config_service import ConfigService
-from utils.config import VIP_CHANNEL_ID
 
 router = Router()
 
@@ -214,15 +213,20 @@ async def process_channel_post(message: Message, state: FSMContext, session: Asy
     buttons_raw = await config.get_value("reaction_buttons")
     buttons = [b.strip() for b in buttons_raw.split(";") if b.strip()] if buttons_raw else ["👍", "👎"]
 
+    vip_id = await config.get_vip_channel_id()
+    if not vip_id:
+        await message.answer("Canal VIP no configurado.", reply_markup=get_admin_manage_content_keyboard())
+        await state.clear()
+        return
     sent = await bot.send_message(
-        chat_id=VIP_CHANNEL_ID,
+        chat_id=vip_id,
         text=message.text,
         reply_markup=get_custom_reaction_keyboard(0, buttons),
     )
 
     real_id = sent.message_id
     await bot.edit_message_reply_markup(
-        chat_id=VIP_CHANNEL_ID,
+        chat_id=vip_id,
         message_id=real_id,
         reply_markup=get_custom_reaction_keyboard(real_id, buttons),
     )

--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -266,8 +266,8 @@ async def set_vip_farewell(message: Message, state: FSMContext, session: AsyncSe
 
 
 @router.callback_query(F.data == "vip_game")
-async def vip_game(callback: CallbackQuery):
-    if not await is_vip_member(callback.bot, callback.from_user.id):
+async def vip_game(callback: CallbackQuery, session: AsyncSession):
+    if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
         return await callback.answer()
     await callback.message.edit_text(
         "Accede al Juego del Diván", reply_markup=get_vip_kb()

--- a/mybot/handlers/channel_access.py
+++ b/mybot/handlers/channel_access.py
@@ -5,17 +5,14 @@ from sqlalchemy import select
 from datetime import datetime
 
 from database.models import PendingChannelRequest, BotConfig
-from utils.config import FREE_CHANNEL_ID as CONFIG_FREE_CHANNEL_ID
+from services.config_service import ConfigService
 
 router = Router()
 
-# Channel ID used to handle join requests for the free channel.
-FREE_CHANNEL_ID = CONFIG_FREE_CHANNEL_ID
-
-
 @router.chat_join_request()
 async def handle_join_request(event: ChatJoinRequest, bot: Bot, session: AsyncSession):
-    if event.chat.id != FREE_CHANNEL_ID:
+    free_id = await ConfigService(session).get_free_channel_id()
+    if event.chat.id != free_id:
         return
     req = PendingChannelRequest(
         user_id=event.from_user.id,
@@ -35,7 +32,8 @@ async def handle_join_request(event: ChatJoinRequest, bot: Bot, session: AsyncSe
 
 @router.chat_member()
 async def handle_chat_member(update: ChatMemberUpdated, bot: Bot, session: AsyncSession):
-    if update.chat.id != FREE_CHANNEL_ID:
+    free_id = await ConfigService(session).get_free_channel_id()
+    if update.chat.id != free_id:
         return
 
     user_id = update.from_user.id

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -41,7 +41,7 @@ async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
             session,
             "admin_main",
         )
-    elif await is_vip_member(bot, user_id):
+    elif await is_vip_member(bot, user_id, session=session):
         await message.answer(
             BOT_MESSAGES["start_welcome_returning_user"],
             reply_markup=get_main_menu_keyboard(),

--- a/mybot/handlers/subscriptions.py
+++ b/mybot/handlers/subscriptions.py
@@ -8,13 +8,12 @@ from services.token_service import validate_token
 from services.subscription_service import SubscriptionService
 from database.models import User
 from utils.text_utils import sanitize_text
-from utils.config import VIP_CHANNEL_ID as CONFIG_VIP_CHANNEL_ID
+from services.config_service import ConfigService
 from services.achievement_service import AchievementService
 
 router = Router()
 
 # Placeholder channel ID. Replace with actual value if not provided via config
-VIP_CHANNEL_ID = CONFIG_VIP_CHANNEL_ID
 
 
 def _duration_to_timedelta(duration: int | str) -> timedelta:
@@ -71,9 +70,10 @@ async def activate_vip(message: Message, session: AsyncSession, bot: Bot):
     await ach_service.check_vip_achievement(user.id, bot=bot)
 
     invite_link = None
-    if VIP_CHANNEL_ID:
+    vip_id = await ConfigService(session).get_vip_channel_id()
+    if vip_id:
         try:
-            link = await bot.create_chat_invite_link(VIP_CHANNEL_ID, member_limit=1)
+            link = await bot.create_chat_invite_link(vip_id, member_limit=1)
             invite_link = link.invite_link
         except Exception:
             invite_link = None

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -10,11 +10,10 @@ from utils.text_utils import sanitize_text
 from services.token_service import TokenService
 from services.subscription_service import SubscriptionService
 from services.achievement_service import AchievementService
-from utils.config import VIP_CHANNEL_ID
+from services.config_service import ConfigService
 
 router = Router()
 
-VIP_CHANNEL_ID_CONST = VIP_CHANNEL_ID
 
 @router.message(CommandStart(deep_link=True))
 async def start_with_token(message: Message, command: CommandObject, session: AsyncSession, bot: Bot):
@@ -57,9 +56,10 @@ async def start_with_token(message: Message, command: CommandObject, session: As
     await ach_service.check_vip_achievement(user.id, bot=bot)
 
     invite_link = None
-    if VIP_CHANNEL_ID_CONST:
+    vip_id = await ConfigService(session).get_vip_channel_id()
+    if vip_id:
         try:
-            link = await bot.create_chat_invite_link(VIP_CHANNEL_ID_CONST, member_limit=1)
+            link = await bot.create_chat_invite_link(vip_id, member_limit=1)
             invite_link = link.invite_link
         except Exception:
             invite_link = None

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -20,7 +20,7 @@ router = Router()
 
 @router.message(Command("vip_menu"))
 async def vip_menu(message: Message, session: AsyncSession):
-    if not await is_vip_member(message.bot, message.from_user.id):
+    if not await is_vip_member(message.bot, message.from_user.id, session=session):
         return
     sub_service = SubscriptionService(session)
     sub = await sub_service.get_subscription(message.from_user.id)
@@ -32,7 +32,7 @@ async def vip_menu(message: Message, session: AsyncSession):
 
 @router.callback_query(F.data == "vip_subscription")
 async def vip_subscription(callback: CallbackQuery, session: AsyncSession):
-    if not await is_vip_member(callback.bot, callback.from_user.id):
+    if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
         return await callback.answer()
     sub_service = SubscriptionService(session)
     sub = await sub_service.get_subscription(callback.from_user.id)
@@ -48,7 +48,7 @@ async def vip_subscription(callback: CallbackQuery, session: AsyncSession):
 
 @router.callback_query(F.data == "vip_game")
 async def vip_game(callback: CallbackQuery, session: AsyncSession):
-    if not await is_vip_member(callback.bot, callback.from_user.id):
+    if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
         return await callback.answer()
     await callback.message.edit_text(
         BOT_MESSAGES["start_welcome_returning_user"],
@@ -60,7 +60,7 @@ async def vip_game(callback: CallbackQuery, session: AsyncSession):
 
 @router.callback_query(F.data == "game_profile")
 async def game_profile(callback: CallbackQuery, session: AsyncSession):
-    if not await is_vip_member(callback.bot, callback.from_user.id):
+    if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
         return await callback.answer()
 
     user_id = callback.from_user.id
@@ -96,7 +96,7 @@ async def game_profile(callback: CallbackQuery, session: AsyncSession):
 @router.callback_query(F.data == "gain_points")
 async def gain_points(callback: CallbackQuery, session: AsyncSession):
     """Show information on how to earn points in the game."""
-    if not await is_vip_member(callback.bot, callback.from_user.id):
+    if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
         return await callback.answer()
 
     await callback.message.edit_text(

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -4,6 +4,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_admin_config_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="📝 Configurar Reacciones", callback_data="config_reaction_buttons")
+    builder.button(text="➕ Agregar canales", callback_data="config_add_channels")
     builder.button(text="⏱️ Schedulers", callback_data="config_scheduler")
     builder.button(text="🔙 Volver", callback_data="admin_back")
     builder.adjust(1)

--- a/mybot/services/config_service.py
+++ b/mybot/services/config_service.py
@@ -7,6 +7,9 @@ from utils.text_utils import sanitize_text
 
 
 class ConfigService:
+    VIP_CHANNEL_KEY = "VIP_CHANNEL_ID"
+    FREE_CHANNEL_KEY = "FREE_CHANNEL_ID"
+
     def __init__(self, session: AsyncSession):
         self.session = session
 
@@ -26,4 +29,24 @@ class ConfigService:
         await self.session.commit()
         await self.session.refresh(entry)
         return entry
+
+    async def get_vip_channel_id(self) -> int | None:
+        value = await self.get_value(self.VIP_CHANNEL_KEY)
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    async def set_vip_channel_id(self, chat_id: int) -> ConfigEntry:
+        return await self.set_value(self.VIP_CHANNEL_KEY, str(chat_id))
+
+    async def get_free_channel_id(self) -> int | None:
+        value = await self.get_value(self.FREE_CHANNEL_KEY)
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    async def set_free_channel_id(self, chat_id: int) -> ConfigEntry:
+        return await self.set_value(self.FREE_CHANNEL_KEY, str(chat_id))
 

--- a/mybot/services/point_service.py
+++ b/mybot/services/point_service.py
@@ -80,7 +80,7 @@ class PointService:
 
         multiplier = 1
         if bot:
-            multiplier = await get_points_multiplier(bot, user_id)
+            multiplier = await get_points_multiplier(bot, user_id, session=self.session)
             event_mult = await EventService(self.session).get_multiplier()
             multiplier *= event_mult
 

--- a/mybot/services/scheduler.py
+++ b/mybot/services/scheduler.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
 from sqlalchemy import select
 
 from database.models import PendingChannelRequest, BotConfig, User
-from utils.config import VIP_CHANNEL_ID, CHANNEL_SCHEDULER_INTERVAL, VIP_SCHEDULER_INTERVAL
+from utils.config import CHANNEL_SCHEDULER_INTERVAL, VIP_SCHEDULER_INTERVAL
 from services.config_service import ConfigService
 
 
@@ -89,10 +89,11 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
         )
         result = await session.execute(stmt)
         expired_users = result.scalars().all()
+        vip_channel_id = await ConfigService(session).get_vip_channel_id()
         for user in expired_users:
             try:
-                if VIP_CHANNEL_ID:
-                    await bot.kick_chat_member(VIP_CHANNEL_ID, user.id)
+                if vip_channel_id:
+                    await bot.kick_chat_member(vip_channel_id, user.id)
             except Exception as e:
                 logging.exception("Failed to remove %s from VIP channel: %s", user.id, e)
             user.role = "free"

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -62,6 +62,8 @@ class AdminConfigStates(StatesGroup):
     waiting_for_reaction_buttons = State()
     waiting_for_channel_interval = State()
     waiting_for_vip_interval = State()
+    waiting_for_vip_channel_id = State()
+    waiting_for_free_channel_id = State()
 
 
 class AdminVipMessageStates(StatesGroup):

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -1,5 +1,7 @@
 from aiogram import Bot
+from sqlalchemy.ext.asyncio import AsyncSession
 from .config import ADMIN_IDS, VIP_IDS, VIP_CHANNEL_ID
+from services.config_service import ConfigService
 import os
 
 DEFAULT_VIP_MULTIPLIER = int(os.environ.get("VIP_POINTS_MULTIPLIER", "2"))
@@ -10,22 +12,27 @@ def is_admin(user_id: int) -> bool:
     return user_id in ADMIN_IDS
 
 
-async def is_vip_member(bot: Bot, user_id: int) -> bool:
+async def is_vip_member(bot: Bot, user_id: int, session: AsyncSession | None = None) -> bool:
     """Check if the user currently belongs to the VIP channel or list."""
     if user_id in VIP_IDS:
         return True
-    if not VIP_CHANNEL_ID:
+    vip_channel_id = VIP_CHANNEL_ID
+    if session:
+        value = await ConfigService(session).get_vip_channel_id()
+        if value is not None:
+            vip_channel_id = value
+    if not vip_channel_id:
         return False
     try:
-        member = await bot.get_chat_member(VIP_CHANNEL_ID, user_id)
+        member = await bot.get_chat_member(vip_channel_id, user_id)
         return member.status in {"member", "administrator", "creator"}
     except Exception:
         return False
 
 
-async def get_points_multiplier(bot: Bot, user_id: int) -> int:
+async def get_points_multiplier(bot: Bot, user_id: int, session: AsyncSession | None = None) -> int:
     """Return VIP multiplier for the user."""
-    if await is_vip_member(bot, user_id):
+    if await is_vip_member(bot, user_id, session=session):
         return DEFAULT_VIP_MULTIPLIER
     return 1
 


### PR DESCRIPTION
## Summary
- add channel ID helpers in `ConfigService`
- let admins store VIP and FREE channel IDs via new menu option
- integrate channel IDs in handlers and services
- make VIP membership checks use stored channel IDs

## Testing
- `python -m py_compile mybot/handlers/admin/config_menu.py mybot/handlers/admin/game_admin.py mybot/handlers/admin/vip_menu.py mybot/handlers/channel_access.py mybot/handlers/start.py mybot/handlers/subscriptions.py mybot/handlers/user/start_token.py mybot/handlers/vip/menu.py mybot/keyboards/admin_config_kb.py mybot/services/config_service.py mybot/services/point_service.py mybot/services/scheduler.py mybot/utils/admin_state.py mybot/utils/user_roles.py`

------
https://chatgpt.com/codex/tasks/task_e_68507823294c8329b550d2b187c256df