### PR TITLE
Add missions admin management

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -67,16 +67,27 @@ class UserAchievement(AsyncAttrs, Base):
 
 class Mission(AsyncAttrs, Base):
     __tablename__ = "missions"
-    id = Column(String, primary_key=True, unique=True) # e.g., 'daily_login', 'event_trivia_challenge'
+    id = Column(String, primary_key=True, unique=True)
     name = Column(String, nullable=False)
     description = Column(Text)
     points_reward = Column(Integer, default=0)
-    type = Column(String, default="one_time") # 'daily', 'weekly', 'one_time', 'event', 'reaction'
+    type = Column(String, default="one_time")
+    target_value = Column(Integer, default=1)
+    duration_days = Column(Integer, default=0)
     is_active = Column(Boolean, default=True)
-    requires_action = Column(Boolean, default=False) # True if requires a specific button click/action outside the bot's menu
-    # action_data puede ser usado para especificar, por ejemplo, qué 'button_id' de reacción completa la misión
-    action_data = Column(JSON, nullable=True) # e.g., {'button_id': 'like_post_1'} or {'target_message_id': 12345}
+    requires_action = Column(Boolean, default=False)
+    action_data = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=func.now())
+
+
+class UserMission(AsyncAttrs, Base):
+    __tablename__ = "user_missions"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"))
+    mission_id = Column(String, ForeignKey("missions.id"))
+    progress = Column(Integer, default=0)
+    completed = Column(Boolean, default=False)
+    completed_at = Column(DateTime, nullable=True)
 
 class Event(AsyncAttrs, Base):
     __tablename__ = "events"

--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -420,6 +420,12 @@ async def handle_daily_checkin(message: Message, session: AsyncSession, bot: Bot
             "checkins",
             bot=bot,
         )
+        await mission_service.update_progress(
+            message.from_user.id,
+            "login_streak",
+            current_value=progress.checkin_streak,
+            bot=bot,
+        )
     if success:
         await message.answer(
             BOT_MESSAGES["checkin_success"].format(points=10)

--- a/mybot/middlewares/points_middleware.py
+++ b/mybot/middlewares/points_middleware.py
@@ -34,6 +34,7 @@ class PointsMiddleware(BaseMiddleware):
                         return await handler(event, data)
 
                     await service.award_message(event.from_user.id, bot)
+                    await mission_service.update_progress(event.from_user.id, "messages", bot=bot)
                     completed = await mission_service.increment_challenge_progress(
                         event.from_user.id,
                         "messages",
@@ -59,6 +60,7 @@ class PointsMiddleware(BaseMiddleware):
                         session.add(user)
                         await session.commit()
                     await service.award_reaction(user, message_id, bot)
+                    await mission_service.update_progress(user_id, "reaction", bot=bot)
                     await bot.send_message(user_id, BOT_MESSAGES["reaction_registered"])
                     completed = await mission_service.increment_challenge_progress(
                         user_id,

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -76,10 +76,10 @@ class AdminMissionStates(StatesGroup):
 
     creating_mission_name = State()
     creating_mission_description = State()
-    creating_mission_points = State()
     creating_mission_type = State()
-    creating_mission_requires_action = State()
-    creating_mission_action_data = State()
+    creating_mission_target = State()
+    creating_mission_reward = State()
+    creating_mission_duration = State()
 
 
 class AdminDailyGiftStates(StatesGroup):

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -123,9 +123,9 @@ def get_admin_manage_content_keyboard():
 def get_admin_content_missions_keyboard():
     """Keyboard for mission management options."""
     keyboard = InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="✏️ Crear Misión", callback_data="admin_create_mission")],
-        [InlineKeyboardButton(text="🔄 Activar / Desactivar Misión", callback_data="admin_toggle_mission")],
-        [InlineKeyboardButton(text="📃 Ver Misiones Activas", callback_data="admin_view_active_missions")],
+        [InlineKeyboardButton(text="🆕 Crear misión", callback_data="admin_create_mission")],
+        [InlineKeyboardButton(text="📋 Ver misiones activas", callback_data="admin_view_missions")],
+        [InlineKeyboardButton(text="🗑️ Eliminar misión", callback_data="admin_delete_mission")],
         [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")]
     ])
     return keyboard

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -10,17 +10,17 @@ DEFAULT_MISSIONS = [
         "name": "Daily Check-in",
         "description": "Registra tu actividad diaria con /checkin",
         "points_reward": 10,
-        "mission_type": "daily",
-        "requires_action": False,
-        "action_data": None,
+        "mission_type": "login_streak",
+        "target_value": 1,
+        "duration_days": 0,
     },
     {
         "name": "Primer Mensaje",
         "description": "Envía tu primer mensaje en el chat",
         "points_reward": 5,
-        "mission_type": "one_time",
-        "requires_action": False,
-        "action_data": None,
+        "mission_type": "messages",
+        "target_value": 1,
+        "duration_days": 0,
     },
 ]
 
@@ -39,10 +39,10 @@ async def main() -> None:
                 await mission_service.create_mission(
                     m["name"],
                     m["description"],
-                    m["points_reward"],
                     m["mission_type"],
-                    m["requires_action"],
-                    m["action_data"],
+                    m.get("target_value", 1),
+                    m["points_reward"],
+                    m.get("duration_days", 0),
                 )
     print("Database initialised")
 


### PR DESCRIPTION
## Summary
- add mission duration and progress tracking models
- expand mission service for creation, progress update and deletion
- update points middleware and checkin handler to evaluate missions
- redesign admin mission FSM with new steps and deletion option
- adjust keyboards and init script for new mission fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507bbc0d088329ad011493cb314835