### PR TITLE
Remove admin channel option from main menu

### DIFF
--- a/mybot/keyboards/admin_main_kb.py
+++ b/mybot/keyboards/admin_main_kb.py
@@ -6,7 +6,6 @@ def get_admin_main_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="📢 Canal VIP", callback_data="admin_vip")
     builder.button(text="💬 Canal Free", callback_data="admin_free")
-    builder.button(text="📣 Administrar Canales", callback_data="admin_channels")
     builder.button(text="🎮 Juego Kinky", callback_data="admin_game")
     builder.button(text="🛠 Configuración del Bot", callback_data="admin_config")
     builder.button(text="🔙 Volver", callback_data="admin_back")


### PR DESCRIPTION
## Summary
- remove `Administrar Canales` button from the admin main keyboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850855ed2bc83299ce5e3ab328e41af