### PR TITLE
Add interactive admin flow for channel setup

### DIFF
--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -11,11 +11,33 @@ def get_admin_config_kb():
     return builder.as_markup()
 
 
+def get_channel_type_kb():
+    """Keyboard to choose which channels to configure."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Solo canal VIP", callback_data="channel_mode_vip")
+    builder.button(text="Solo canal FREE", callback_data="channel_mode_free")
+    builder.button(
+        text="Ambos canales (VIP y FREE)", callback_data="channel_mode_both"
+    )
+    builder.button(text="🔙 Volver", callback_data="admin_config")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
 def get_scheduler_config_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="⏲ Intervalo Canal", callback_data="set_channel_interval")
     builder.button(text="⏲ Intervalo VIP", callback_data="set_vip_interval")
     builder.button(text="▶ Ejecutar Ahora", callback_data="run_schedulers_now")
     builder.button(text="🔙 Volver", callback_data="admin_config")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_config_done_kb():
+    """Keyboard shown when channel configuration finishes."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Aceptar", callback_data="admin_config")
+    builder.button(text="Regresar al menú anterior", callback_data="admin_back")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -60,6 +60,7 @@ class AdminConfigStates(StatesGroup):
     """States for bot configuration options."""
 
     waiting_for_reaction_buttons = State()
+    waiting_for_channel_choice = State()
     waiting_for_channel_interval = State()
     waiting_for_vip_interval = State()
     waiting_for_vip_channel_id = State()


### PR DESCRIPTION
## Summary
- add `waiting_for_channel_choice` state for admins
- provide keyboards to pick channel type and finalize setup
- implement interactive logic for VIP/FREE/both channel configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685086c0e2cc8329a96ce39dfb3abf67