### PR TITLE
Add missions button to VIP menu

### DIFF
--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -46,6 +46,17 @@ async def vip_subscription(callback: CallbackQuery, session: AsyncSession):
     await callback.answer()
 
 
+@router.callback_query(F.data == "vip_missions")
+async def vip_missions(callback: CallbackQuery, session: AsyncSession):
+    if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Aquí verás las misiones disponibles para ganar puntos extra. Pronto estarán activas.",
+        reply_markup=get_vip_kb(),
+    )
+    await callback.answer()
+
+
 @router.callback_query(F.data == "vip_game")
 async def vip_game(callback: CallbackQuery, session: AsyncSession):
     if not await is_vip_member(callback.bot, callback.from_user.id, session=session):

--- a/mybot/keyboards/vip_kb.py
+++ b/mybot/keyboards/vip_kb.py
@@ -6,6 +6,7 @@ def get_vip_kb():
 
     builder = InlineKeyboardBuilder()
     builder.button(text="🧾 Mi Suscripción", callback_data="vip_subscription")
+    builder.button(text="🗺️ Misiones", callback_data="vip_missions")
     builder.button(text="🎮 Juego del Diván", callback_data="vip_game")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -15,6 +15,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Placeholder structure for future missions
+MISSION_PLACEHOLDER: list = []
+
 class MissionService:
     def __init__(self, session: AsyncSession):
         self.session = session


### PR DESCRIPTION
## Summary
- expand VIP inline menu with a `Misiones` button
- handle `vip_missions` callbacks to display a placeholder message
- create a mission placeholder list for future use

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850923788888329b31c641acefcafb9