### PR TITLE
Add daily mission support

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -70,7 +70,7 @@ class Mission(AsyncAttrs, Base):
     id = Column(String, primary_key=True, unique=True)
     name = Column(String, nullable=False)
     description = Column(Text)
-    points_reward = Column(Integer, default=0)
+    reward_points = Column(Integer, default=0)
     type = Column(String, default="one_time")
     target_value = Column(Integer, default=1)
     duration_days = Column(Integer, default=0)

--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -439,7 +439,7 @@ async def admin_view_active_missions(callback: CallbackQuery, session: AsyncSess
         if m.duration_days:
             end = m.created_at + datetime.timedelta(days=m.duration_days)
             remaining = str((end - now).days)
-        lines.append(f"🗒️ {m.name} | 📊 {m.target_value} | 🎁 {m.points_reward} | ⏳ {remaining}d")
+        lines.append(f"🗒️ {m.name} | 📊 {m.target_value} | 🎁 {m.reward_points} | ⏳ {remaining}d")
     text = "Misiones activas:" if lines else "No hay misiones activas."
     if lines:
         text += "\n" + "\n".join(lines)

--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -276,13 +276,13 @@ async def handle_complete_mission_callback(callback: CallbackQuery, session: Asy
     completed, completed_mission_obj = await mission_service.complete_mission(user_id, mission_id)
 
     if completed:
-        await point_service.add_points(user_id, completed_mission_obj.points_reward, bot=callback.bot)
+        await point_service.add_points(user_id, completed_mission_obj.reward_points, bot=callback.bot)
         
         # Opcional: Otorgar un logro por la primera misión
         if not user.missions_completed: # Si es la primera misión del usuario
              await achievement_service.grant_achievement(user_id, "first_mission")
 
-        alert_message = f"🎉 ¡Misión '{completed_mission_obj.name}' completada! Ganaste `{completed_mission_obj.points_reward}` puntos."
+        alert_message = f"🎉 ¡Misión '{completed_mission_obj.name}' completada! Ganaste `{completed_mission_obj.reward_points}` puntos."
 
         await callback.answer(alert_message, show_alert=True)
 
@@ -353,8 +353,8 @@ async def handle_reaction_callback(callback: CallbackQuery, session: AsyncSessio
             if not is_completed_for_period:
                 completed, mission_obj = await mission_service.complete_mission(user_id, mission.id, target_message_id=target_message_id)
                 if completed:
-                    mission_completed_message = f"\n\n🎉 ¡Misión completada: **{mission_obj.name}**! Ganaste `{mission_obj.points_reward}` puntos adicionales."
-                    await point_service.add_points(user_id, mission_obj.points_reward, bot=callback.bot)
+                    mission_completed_message = f"\n\n🎉 ¡Misión completada: **{mission_obj.name}**! Ganaste `{mission_obj.reward_points}` puntos adicionales."
+                    await point_service.add_points(user_id, mission_obj.reward_points, bot=callback.bot)
 
     alert_message = f"¡Reacción registrada! Ganaste `{base_points_for_reaction}` puntos."
     alert_message += mission_completed_message

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -47,6 +47,10 @@ class MissionService:
                 return filtered_missions
         return missions
 
+    async def get_daily_missions(self, user_id: int | None = None) -> list[Mission]:
+        """Return active missions of type 'daily'."""
+        return await self.get_active_missions(user_id=user_id, mission_type="daily")
+
     async def get_mission_by_id(self, mission_id: str) -> Mission | None:
         return await self.session.get(Mission, mission_id)
 
@@ -118,7 +122,7 @@ class MissionService:
              from services.point_service import PointService
              point_service = PointService(self.session)
 
-        await point_service.add_points(user_id, mission.points_reward)
+        await point_service.add_points(user_id, mission.reward_points)
 
         # Update last reset timestamps for daily/weekly missions
         if mission.type == "daily":
@@ -148,7 +152,7 @@ class MissionService:
             id=mission_id,
             name=sanitize_text(name),
             description=sanitize_text(description),
-            points_reward=reward_points,
+            reward_points=reward_points,
             type=mission_type,
             target_value=target_value,
             duration_days=duration_days,
@@ -197,11 +201,11 @@ class MissionService:
             if progress >= mission.target_value:
                 record.completed = True
                 record.completed_at = datetime.datetime.utcnow()
-                await self.point_service.add_points(user_id, mission.points_reward, bot=bot)
+                await self.point_service.add_points(user_id, mission.reward_points, bot=bot)
                 if bot:
                     await bot.send_message(
                         user_id,
-                        f"🎉 ¡Has completado la misión {mission.name}! +{mission.points_reward} puntos",
+                        f"🎉 ¡Has completado la misión {mission.name}! +{mission.reward_points} puntos",
                     )
         await self.session.commit()
 

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -25,7 +25,7 @@ def get_missions_keyboard(missions: list, offset: int = 0):
     keyboard = []
     # Display up to 5 missions per page
     for mission in missions[offset:offset+5]:
-        keyboard.append([InlineKeyboardButton(text=f"{mission.name} ({mission.points_reward} Pts)", callback_data=f"mission_{mission.id}")])
+        keyboard.append([InlineKeyboardButton(text=f"{mission.name} ({mission.reward_points} Pts)", callback_data=f"mission_{mission.id}")])
     
     # Add navigation buttons if there are more missions
     nav_buttons = []

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -55,7 +55,7 @@ async def get_profile_message(user: User, active_missions: list[Mission], sessio
     missions_text = BOT_MESSAGES["profile_no_active_missions"]
     if active_missions:
         missions_list = [
-            f"• {mission.name} ({mission.points_reward} Puntos)"
+            f"• {mission.name} ({mission.reward_points} Puntos)"
             for mission in active_missions
         ]
         missions_text = BOT_MESSAGES["profile_active_missions_title"] + "\n" + "\n".join(missions_list)
@@ -75,7 +75,7 @@ async def get_mission_details_message(mission: Mission) -> str:
     return BOT_MESSAGES["mission_details_text"].format(
         mission_name=mission.name,
         mission_description=mission.description,
-        points_reward=mission.points_reward,
+        points_reward=mission.reward_points,
         mission_type=mission.type.capitalize()
     )
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -9,7 +9,7 @@ DEFAULT_MISSIONS = [
     {
         "name": "Daily Check-in",
         "description": "Registra tu actividad diaria con /checkin",
-        "points_reward": 10,
+        "reward_points": 10,
         "mission_type": "login_streak",
         "target_value": 1,
         "duration_days": 0,
@@ -17,7 +17,7 @@ DEFAULT_MISSIONS = [
     {
         "name": "Primer Mensaje",
         "description": "Envía tu primer mensaje en el chat",
-        "points_reward": 5,
+        "reward_points": 5,
         "mission_type": "messages",
         "target_value": 1,
         "duration_days": 0,
@@ -41,7 +41,7 @@ async def main() -> None:
                     m["description"],
                     m["mission_type"],
                     m.get("target_value", 1),
-                    m["points_reward"],
+                    m["reward_points"],
                     m.get("duration_days", 0),
                 )
     print("Database initialised")


### PR DESCRIPTION
## Summary
- rename `points_reward` field to `reward_points`
- add `get_daily_missions` helper in mission service
- update handlers and utils for new field name
- display actual missions for VIP users
- adjust DB initialisation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850942669cc8329bbf2b8bb91599791