### PR TITLE
Implement basic user mission progress

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -90,6 +90,19 @@ class UserMission(AsyncAttrs, Base):
     completed = Column(Boolean, default=False)
     completed_at = Column(DateTime, nullable=True)
 
+
+class UserMissionProgress(AsyncAttrs, Base):
+    """Tracks progress of a mission per user."""
+
+    __tablename__ = "user_mission_progress"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"))
+    mission_id = Column(String, ForeignKey("missions.id"))
+    progress_value = Column(Integer, default=0)
+    completed = Column(Boolean, default=False)
+    completed_at = Column(DateTime, nullable=True)
+
 class Event(AsyncAttrs, Base):
     __tablename__ = "events"
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -6,7 +6,7 @@ from sqlalchemy import select, update
 from database.models import (
     Mission,
     User,
-    UserMission,
+    UserMissionProgress,
     Challenge,
     UserChallengeProgress,
 )
@@ -182,22 +182,23 @@ class MissionService:
     ) -> None:
         missions = await self.get_active_missions(mission_type=mission_type)
         for mission in missions:
-            stmt = select(UserMission).where(
-                UserMission.user_id == user_id, UserMission.mission_id == mission.id
+            stmt = select(UserMissionProgress).where(
+                UserMissionProgress.user_id == user_id,
+                UserMissionProgress.mission_id == mission.id,
             )
             result = await self.session.execute(stmt)
             record = result.scalar_one_or_none()
             if not record:
-                record = UserMission(user_id=user_id, mission_id=mission.id)
+                record = UserMissionProgress(user_id=user_id, mission_id=mission.id)
                 self.session.add(record)
             if record.completed:
                 continue
             if mission_type == "login_streak" and current_value is not None:
                 progress = current_value
-                record.progress = progress
+                record.progress_value = progress
             else:
-                record.progress += increment
-                progress = record.progress
+                record.progress_value += increment
+                progress = record.progress_value
             if progress >= mission.target_value:
                 record.completed = True
                 record.completed_at = datetime.datetime.utcnow()


### PR DESCRIPTION
## Summary
- add `UserMissionProgress` database model
- track mission progress using this model

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685094da5c608329a9349bfe26f90ba6