### PR TITLE
Implement mission completion notifications

### DIFF
--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -273,18 +273,17 @@ async def handle_complete_mission_callback(callback: CallbackQuery, session: Asy
         return
 
     # Intentar completar la misión
-    completed, completed_mission_obj = await mission_service.complete_mission(user_id, mission_id)
+    completed, completed_mission_obj = await mission_service.complete_mission(
+        user_id,
+        mission_id,
+        bot=callback.bot,
+    )
 
     if completed:
-        await point_service.add_points(user_id, completed_mission_obj.reward_points, bot=callback.bot)
-        
         # Opcional: Otorgar un logro por la primera misión
         if not user.missions_completed: # Si es la primera misión del usuario
              await achievement_service.grant_achievement(user_id, "first_mission")
-
-        alert_message = f"🎉 ¡Misión '{completed_mission_obj.name}' completada! Ganaste `{completed_mission_obj.reward_points}` puntos."
-
-        await callback.answer(alert_message, show_alert=True)
+        await callback.answer("Misión completada!", show_alert=True)
 
         # Volver al menú de misiones y actualizarlo
         active_missions = await mission_service.get_active_missions(user_id=user_id) # Volver a obtener las misiones activas
@@ -351,10 +350,14 @@ async def handle_reaction_callback(callback: CallbackQuery, session: AsyncSessio
             is_completed_for_period, _ = await mission_service.check_mission_completion_status(user, mission, target_message_id=target_message_id) # Pasa target_message_id
             
             if not is_completed_for_period:
-                completed, mission_obj = await mission_service.complete_mission(user_id, mission.id, target_message_id=target_message_id)
+                completed, mission_obj = await mission_service.complete_mission(
+                    user_id,
+                    mission.id,
+                    target_message_id=target_message_id,
+                    bot=callback.bot,
+                )
                 if completed:
-                    mission_completed_message = f"\n\n🎉 ¡Misión completada: **{mission_obj.name}**! Ganaste `{mission_obj.reward_points}` puntos adicionales."
-                    await point_service.add_points(user_id, mission_obj.reward_points, bot=callback.bot)
+                    mission_completed_message = f"\n\n🎉 ¡Misión completada: **{mission_obj.name}**!"
 
     alert_message = f"¡Reacción registrada! Ganaste `{base_points_for_reaction}` puntos."
     alert_message += mission_completed_message

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -1,6 +1,7 @@
 # utils/keyboard_utils.py
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton, ReplyKeyboardMarkup, KeyboardButton
 from database.models import User
+from utils.messages import BOT_MESSAGES
 
 
 def get_main_menu_keyboard():
@@ -251,6 +252,19 @@ def get_back_keyboard(callback_data: str) -> InlineKeyboardMarkup:
     """Return a simple keyboard with a single back button."""
     keyboard = [
         [InlineKeyboardButton(text="🔙 Volver", callback_data=callback_data)]
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def get_mission_completed_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard shown after completing a mission."""
+    keyboard = [
+        [
+            InlineKeyboardButton(
+                text=BOT_MESSAGES["view_all_missions_button_text"],
+                callback_data="menu:missions",
+            )
+        ]
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -116,3 +116,11 @@ async def get_ranking_message(users_ranking: list[User]) -> str:
 
     return ranking_text
 
+
+async def get_mission_completed_message(mission: Mission) -> str:
+    """Return a formatted message for mission completion."""
+    return BOT_MESSAGES["mission_completed_feedback"].format(
+        mission_name=mission.name,
+        points_reward=mission.reward_points,
+    )
+

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -25,6 +25,7 @@ BOT_MESSAGES = {
     "mission_not_found": "Ese desafío no existe o ya expiró.",
     "mission_already_completed": "Ya lo completaste. Buen trabajo.",
     "mission_completed_success": "✅ ¡Desafío completado! Ganaste `{points_reward}` puntos.",
+    "mission_completed_feedback": "🎉 ¡Misión '{mission_name}' completada! Ganaste `{points_reward}` puntos.",
     "mission_level_up_bonus": "🚀 Subiste de nivel. Ahora estás en el nivel `{user_level}`. Las cosas se pondrán más interesantes.",
     "mission_achievement_unlocked": "\n🏆 Logro desbloqueado: *{achievement_name}*",
     "mission_completion_failed": "❌ No pudimos registrar este desafío. Revisa si ya lo hiciste antes o si aún está activo.",


### PR DESCRIPTION
## Summary
- add new mission completion feedback template
- include mission completion helpers in message and keyboard utils
- notify users via MissionService when a mission is finished
- remove double point assignment and clean callbacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68509f64ddc48329bedb1b4468365c52