### PR TITLE
Implement basic badge system

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -137,10 +137,12 @@ class Badge(AsyncAttrs, Base):
     __tablename__ = "badges"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String, nullable=False)
+    name = Column(String, unique=True, nullable=False)
     description = Column(String, nullable=True)
-    requirement = Column(String, nullable=False)
-    emoji = Column(String, nullable=True)
+    icon = Column(String, nullable=True)
+    condition_type = Column(String, nullable=False)
+    condition_value = Column(Integer, nullable=False)
+    is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=func.now())
 
 

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -109,3 +109,20 @@ BOT_MESSAGES = {
     "reward_created": "✅ Recompensa creada.",
     "invalid_number": "Ingresa un número válido.",
 }
+
+# Textos descriptivos para las insignias disponibles en el sistema.
+# El identificador sirve como clave de referencia interna.
+BADGE_TEXTS = {
+    "first_message": {
+        "name": "Primer Mensaje",
+        "description": "Envía tu primer mensaje en el chat",
+    },
+    "conversador": {
+        "name": "Conversador",
+        "description": "Alcanza 100 mensajes enviados",
+    },
+    "invitador": {
+        "name": "Invitador",
+        "description": "Consigue 5 invitaciones exitosas",
+    },
+}


### PR DESCRIPTION
## Summary
- expand `Badge` model with condition fields and active flag
- add badge management helpers in achievement service
- store badge names/descriptions in messages module

## Testing
- `python -m py_compile mybot/database/models.py mybot/services/achievement_service.py mybot/utils/messages.py`

------
https://chatgpt.com/codex/tasks/task_e_6850a235cbc483299ac9a0f959427a3d