### PR TITLE
Refactor admin menu structure

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -8,7 +8,6 @@ from keyboards.admin_main_kb import get_admin_main_kb
 from utils.user_roles import is_admin
 from utils.keyboard_utils import (
     get_main_menu_keyboard,
-    get_admin_main_keyboard,
     get_admin_manage_content_keyboard,
 )
 from keyboards.common import get_back_kb
@@ -26,7 +25,7 @@ from .free_menu import router as free_router
 from .config_menu import router as config_router
 from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
-from .game_admin import router as game_admin_router, show_users_page
+from .game_admin import router as game_admin_router
 from .event_admin import router as event_admin_router
 
 router = Router()
@@ -139,13 +138,6 @@ async def admin_back(callback: CallbackQuery, session: AsyncSession):
     await callback.answer()
 
 
-@router.callback_query(F.data == "admin_manage_users")
-async def admin_manage_users(callback: CallbackQuery, session: AsyncSession):
-    if not is_admin(callback.from_user.id):
-        return await callback.answer()
-    await show_users_page(callback.message, session, 0)
-    await callback.answer()
-
 
 @router.callback_query(F.data == "admin_manage_content")
 async def admin_manage_content(callback: CallbackQuery, session: AsyncSession):
@@ -184,7 +176,7 @@ async def back_to_admin_main(callback: CallbackQuery, session: AsyncSession):
     await update_menu(
         callback,
         "Bienvenido al panel de administraci\u00f3n, Diana.",
-        get_admin_main_keyboard(),
+        get_admin_main_kb(),
         session,
         "admin_main",
     )

--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -29,7 +29,6 @@ from utils.keyboard_utils import (
     get_confirm_purchase_keyboard,
     get_ranking_keyboard,
     get_reaction_keyboard,
-    get_admin_main_keyboard,
     get_root_menu,
     get_parent_menu,
     get_child_menu,

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -83,16 +83,6 @@ def get_custom_reaction_keyboard(message_id: int, buttons: list[str]) -> InlineK
         like, dislike = "👍", "👎"
     return get_reaction_keyboard(message_id, like, dislike)
 
-def get_admin_main_keyboard():
-    """Returns the top level keyboard for admin actions."""
-    keyboard = InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="🧑‍💼 Gestionar Usuarios", callback_data="admin_manage_users")],
-        [InlineKeyboardButton(text="🎮 Gestionar Contenido/Juego", callback_data="admin_manage_content")],
-        [InlineKeyboardButton(text="🎉 Gestionar Eventos y Sorteos", callback_data="admin_manage_events_sorteos")],
-        [InlineKeyboardButton(text="⚙️ Configuración del Bot", callback_data="admin_bot_config")],
-        [InlineKeyboardButton(text="🔙 Menú Principal", callback_data="menu_principal")]
-    ])
-    return keyboard
 
 def get_admin_manage_users_keyboard():
     """Returns the keyboard for user management options in the admin panel."""
@@ -109,6 +99,7 @@ def get_admin_manage_users_keyboard():
 def get_admin_manage_content_keyboard():
     """Returns the keyboard for content management options."""
     keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="👥 Gestionar Usuarios", callback_data="admin_manage_users")],
         [InlineKeyboardButton(text="📌 Misiones", callback_data="admin_content_missions")],
         [InlineKeyboardButton(text="🏅 Insignias", callback_data="admin_content_badges")],
         [InlineKeyboardButton(text="📈 Niveles", callback_data="admin_content_levels")],
@@ -116,6 +107,7 @@ def get_admin_manage_content_keyboard():
         [InlineKeyboardButton(text="📦 Subastas", callback_data="admin_content_auctions")],
         [InlineKeyboardButton(text="🎁 Regalos Diarios", callback_data="admin_content_daily_gifts")],
         [InlineKeyboardButton(text="🕹 Minijuegos", callback_data="admin_content_minigames")],
+        [InlineKeyboardButton(text="🎉 Eventos y Sorteos", callback_data="admin_manage_events_sorteos")],
         [InlineKeyboardButton(text="📝 Publicar en Canal", callback_data="admin_send_channel_post")],
         [InlineKeyboardButton(text="🔙 Volver al Menú Principal de Administrador", callback_data="admin_main_menu")]
     ])


### PR DESCRIPTION
## Summary
- remove deprecated `get_admin_main_keyboard`
- include user and event management buttons in the game menu
- clean up imports and callbacks to use `get_admin_main_kb`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850abc4c4ec83298b4ecb3a15cfd198