### PR TITLE
Automated badge awards

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -1,5 +1,5 @@
 # database/models.py
-from sqlalchemy import Column, Integer, String, BigInteger, DateTime, Boolean, JSON, Text, ForeignKey, Float
+from sqlalchemy import Column, Integer, String, BigInteger, DateTime, Boolean, JSON, Text, ForeignKey, Float, UniqueConstraint
 from uuid import uuid4
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
@@ -149,9 +149,14 @@ class Badge(AsyncAttrs, Base):
 class UserBadge(AsyncAttrs, Base):
     __tablename__ = "user_badges"
 
-    user_id = Column(BigInteger, ForeignKey("users.id"), primary_key=True)
-    badge_id = Column(Integer, ForeignKey("badges.id"), primary_key=True)
-    earned_at = Column(DateTime, default=func.now())
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"), nullable=False)
+    badge_id = Column(Integer, ForeignKey("badges.id"), nullable=False)
+    awarded_at = Column(DateTime, default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "badge_id", name="uix_user_badges"),
+    )
 
 
 class Level(AsyncAttrs, Base):

--- a/mybot/services/achievement_service.py
+++ b/mybot/services/achievement_service.py
@@ -148,7 +148,11 @@ class AchievementService:
         badges = (await self.session.execute(stmt)).scalars().all()
         unlockable = []
         for badge in badges:
-            existing = await self.session.get(UserBadge, {"user_id": user_id, "badge_id": badge.id})
+            stmt = select(UserBadge).where(
+                UserBadge.user_id == user_id,
+                UserBadge.badge_id == badge.id,
+            )
+            existing = (await self.session.execute(stmt)).scalar_one_or_none()
             if existing:
                 continue
             if await self._badge_condition_met(user_id, badge):
@@ -159,7 +163,11 @@ class AchievementService:
         badge = await self.session.get(Badge, badge_id)
         if not badge or not badge.is_active:
             return False
-        existing = await self.session.get(UserBadge, {"user_id": user_id, "badge_id": badge_id})
+        stmt = select(UserBadge).where(
+            UserBadge.user_id == user_id,
+            UserBadge.badge_id == badge_id,
+        )
+        existing = (await self.session.execute(stmt)).scalar_one_or_none()
         if existing:
             return False
         if not await self._badge_condition_met(user_id, badge):

--- a/mybot/services/badge_service.py
+++ b/mybot/services/badge_service.py
@@ -29,7 +29,11 @@ class BadgeService:
         return True
 
     async def grant_badge(self, user_id: int, badge: Badge) -> bool:
-        existing = await self.session.get(UserBadge, {"user_id": user_id, "badge_id": badge.id})
+        stmt = select(UserBadge).where(
+            UserBadge.user_id == user_id,
+            UserBadge.badge_id == badge.id,
+        )
+        existing = (await self.session.execute(stmt)).scalar_one_or_none()
         if existing:
             return False
         self.session.add(UserBadge(user_id=user_id, badge_id=badge.id))
@@ -39,7 +43,11 @@ class BadgeService:
     async def check_badges(self, user: User, progress: UserProgress, bot: Bot | None = None):
         badges = await self.list_badges()
         for badge in badges:
-            existing = await self.session.get(UserBadge, {"user_id": user.id, "badge_id": badge.id})
+            stmt = select(UserBadge).where(
+                UserBadge.user_id == user.id,
+                UserBadge.badge_id == badge.id,
+            )
+            existing = (await self.session.execute(stmt)).scalar_one_or_none()
             if existing:
                 continue
             req = badge.requirement.lower()

--- a/mybot/services/point_service.py
+++ b/mybot/services/point_service.py
@@ -34,6 +34,14 @@ class PointService:
         await self.session.commit()
         ach_service = AchievementService(self.session)
         await ach_service.check_message_achievements(user_id, progress.messages_sent, bot=bot)
+        new_badges = await ach_service.check_user_badges(user_id)
+        for badge in new_badges:
+            await ach_service.award_badge(user_id, badge.id)
+            if bot:
+                await bot.send_message(
+                    user_id,
+                    f"🏅 Has obtenido la insignia {badge.icon or ''} {badge.name}!",
+                )
         return progress
 
     async def award_reaction(
@@ -45,10 +53,28 @@ class PointService:
             user.channel_reactions = {}
         user.channel_reactions[str(message_id)] = True
         progress = await self.add_points(user.id, 0.5, bot=bot)
+        ach_service = AchievementService(self.session)
+        new_badges = await ach_service.check_user_badges(user.id)
+        for badge in new_badges:
+            await ach_service.award_badge(user.id, badge.id)
+            if bot:
+                await bot.send_message(
+                    user.id,
+                    f"🏅 Has obtenido la insignia {badge.icon or ''} {badge.name}!",
+                )
         return progress
 
     async def award_poll(self, user_id: int, bot: Bot) -> UserProgress:
         progress = await self.add_points(user_id, 2, bot=bot)
+        ach_service = AchievementService(self.session)
+        new_badges = await ach_service.check_user_badges(user_id)
+        for badge in new_badges:
+            await ach_service.award_badge(user_id, badge.id)
+            if bot:
+                await bot.send_message(
+                    user_id,
+                    f"🏅 Has obtenido la insignia {badge.icon or ''} {badge.name}!",
+                )
         return progress
 
     async def daily_checkin(self, user_id: int, bot: Bot) -> tuple[bool, UserProgress]:
@@ -65,6 +91,14 @@ class PointService:
         await self.session.commit()
         ach_service = AchievementService(self.session)
         await ach_service.check_checkin_achievements(user_id, progress.checkin_streak, bot=bot)
+        new_badges = await ach_service.check_user_badges(user_id)
+        for badge in new_badges:
+            await ach_service.award_badge(user_id, badge.id)
+            if bot:
+                await bot.send_message(
+                    user_id,
+                    f"🏅 Has obtenido la insignia {badge.icon or ''} {badge.name}!",
+                )
         return True, progress
 
     async def add_points(self, user_id: int, points: float, *, bot: Bot | None = None) -> UserProgress:
@@ -94,9 +128,16 @@ class PointService:
         await self.session.refresh(user)
         level_service = LevelService(self.session)
         await level_service.check_for_level_up(user, bot=bot)
-        from services.badge_service import BadgeService
-        badge_service = BadgeService(self.session)
-        await badge_service.check_badges(user, progress, bot=bot)
+
+        ach_service = AchievementService(self.session)
+        new_badges = await ach_service.check_user_badges(user_id)
+        for badge in new_badges:
+            await ach_service.award_badge(user_id, badge.id)
+            if bot:
+                await bot.send_message(
+                    user_id,
+                    f"🏅 Has obtenido la insignia {badge.icon or ''} {badge.name}!",
+                )
         logger.info(
             f"User {user_id} gained {total} points (base {points}, x{multiplier}). Total: {progress.total_points}"
         )


### PR DESCRIPTION
## Summary
- create unique `UserBadge` table with `id` field
- check for new badges whenever points are awarded
- grant badges automatically after messages, reactions, polls and check‑ins
- adjust services to query `UserBadge` correctly

## Testing
- `python -m py_compile mybot/services/point_service.py mybot/services/achievement_service.py mybot/services/badge_service.py mybot/database/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6850aa3d9e388329bc1a3ee55cba6a57