### PR TITLE
Enable mission admin menu

### DIFF
--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -117,7 +117,10 @@ def get_admin_content_missions_keyboard():
     """Keyboard for mission management options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="Bot\u00f3n de prueba", callback_data="admin_game_test")],
+            [InlineKeyboardButton(text="➕ Crear Misión", callback_data="admin_create_mission")],
+            [InlineKeyboardButton(text="✅/❌ Activar/Desactivar", callback_data="admin_toggle_mission")],
+            [InlineKeyboardButton(text="👁 Ver Activas", callback_data="admin_view_missions")],
+            [InlineKeyboardButton(text="🗑 Eliminar", callback_data="admin_delete_mission")],
             [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
         ]
     )


### PR DESCRIPTION
## Summary
- enable admin mission options by updating the mission menu keyboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850af2528f083298b1ea516d67aa79e