### PR TITLE
Add manual badge assignment feature

### DIFF
--- a/mybot/keyboards/admin_vip_kb.py
+++ b/mybot/keyboards/admin_vip_kb.py
@@ -6,6 +6,7 @@ def get_admin_vip_kb() -> InlineKeyboardBuilder:
     builder.button(text="📊 Estadísticas", callback_data="vip_stats")
     builder.button(text="🔑 Generar Token", callback_data="vip_generate_token")
     builder.button(text="👥 Suscriptores", callback_data="vip_manage")
+    builder.button(text="🏅 Asignar insignia", callback_data="vip_manual_badge")
     builder.button(text="⚙️ Configuración", callback_data="vip_config")
     builder.button(text="🔙 Volver", callback_data="admin_back")
     builder.adjust(1)

--- a/mybot/services/achievement_service.py
+++ b/mybot/services/achievement_service.py
@@ -159,7 +159,7 @@ class AchievementService:
                 unlockable.append(badge)
         return unlockable
 
-    async def award_badge(self, user_id: int, badge_id: int) -> bool:
+    async def award_badge(self, user_id: int, badge_id: int, *, force: bool = False) -> bool:
         badge = await self.session.get(Badge, badge_id)
         if not badge or not badge.is_active:
             return False
@@ -170,7 +170,7 @@ class AchievementService:
         existing = (await self.session.execute(stmt)).scalar_one_or_none()
         if existing:
             return False
-        if not await self._badge_condition_met(user_id, badge):
+        if not force and not await self._badge_condition_met(user_id, badge):
             return False
         self.session.add(UserBadge(user_id=user_id, badge_id=badge_id))
         await self.session.commit()

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -128,3 +128,10 @@ class AdminRewardStates(StatesGroup):
     creating_reward_description = State()
     creating_reward_cost = State()
     creating_reward_stock = State()
+
+
+class AdminManualBadgeStates(StatesGroup):
+    """States for manually awarding badges."""
+
+    waiting_for_user = State()
+    waiting_for_badge = State()


### PR DESCRIPTION
## Summary
- allow admins to manually award badges
- add button in VIP admin menu for manual badge assignment
- implement state flow for selecting user and badge
- extend `AchievementService.award_badge` to support forced awards

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850b31bdb98832984d521f6b5ec0751