### PR TITLE
Add user level display

### DIFF
--- a/mybot/keyboards/vip_game_kb.py
+++ b/mybot/keyboards/vip_game_kb.py
@@ -3,6 +3,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 def get_game_menu_kb():
     builder = InlineKeyboardBuilder()
+    builder.button(text="\ud83d\udcc8 Ver mi nivel", callback_data="view_level")
     builder.button(text="Mi perfil", callback_data="game_profile")
     builder.button(text="Ganar puntos", callback_data="gain_points")
     builder.adjust(1)

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -7,6 +7,7 @@ from utils.messages import BOT_MESSAGES
 def get_main_menu_keyboard():
     """Returns the main inline menu keyboard."""
     keyboard = [
+        [InlineKeyboardButton(text="📈 Ver mi nivel", callback_data="view_level")],
         [InlineKeyboardButton(text="👤 Perfil", callback_data="menu:profile")],
         [InlineKeyboardButton(text="🗺 Misiones", callback_data="menu:missions")],
         [InlineKeyboardButton(text="🎁 Recompensas", callback_data="menu:rewards")],

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -127,3 +127,11 @@ BADGE_TEXTS = {
         "description": "Consigue 5 invitaciones exitosas",
     },
 }
+
+# Plantilla de mensaje para mostrar el nivel del usuario
+NIVEL_TEMPLATE = """
+🎮 Tu nivel actual: {current_level}
+✨ Puntos totales: {points}
+📊 Progreso hacia el siguiente nivel: {percentage:.1%}
+🎯 Te faltan {points_needed} puntos para alcanzar el nivel {next_level}.
+"""


### PR DESCRIPTION
## Summary
- add simple level utilities and table
- expose `view_level` menu option and handler
- show progress message using `NIVEL_TEMPLATE`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850b731f5fc83298b4ab35a03c946ed