### PR TITLE
Improve menu flow and auto-delete errors

### DIFF
--- a/mybot/handlers/admin/channel_admin.py
+++ b/mybot/handlers/admin/channel_admin.py
@@ -5,7 +5,7 @@ from aiogram.fsm.state import StatesGroup, State
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from utils.user_roles import is_admin
-from utils.menu_utils import update_menu
+from utils.menu_utils import update_menu, send_temporary_reply
 from keyboards.admin_channels_kb import get_admin_channels_kb, get_wait_time_kb
 from keyboards.common import get_back_kb
 from services.channel_service import ChannelService
@@ -66,7 +66,7 @@ async def receive_vip_channel(message: Message, state: FSMContext, session: Asyn
         try:
             chat_id = int(message.text.strip())
         except (TypeError, ValueError):
-            await message.answer("ID inv\u00e1lido. Intenta de nuevo.")
+            await send_temporary_reply(message, "ID inválido. Intenta de nuevo.")
             return
     await state.update_data(vip_channel_id=chat_id)
     await message.answer(
@@ -87,7 +87,7 @@ async def receive_free_channel(message: Message, state: FSMContext, session: Asy
         try:
             chat_id = int(message.text.strip())
         except (TypeError, ValueError):
-            await message.answer("ID inv\u00e1lido. Intenta de nuevo.")
+            await send_temporary_reply(message, "ID inválido. Intenta de nuevo.")
             return
     data = await state.get_data()
     vip_id = int(data.get("vip_channel_id"))

--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -6,7 +6,7 @@ from sqlalchemy import select, func
 import datetime
 
 from utils.user_roles import is_admin
-from utils.menu_utils import update_menu
+from utils.menu_utils import update_menu, send_temporary_reply
 from utils.keyboard_utils import (
     get_admin_manage_users_keyboard,
     get_admin_users_list_keyboard,
@@ -132,7 +132,7 @@ async def process_points_amount(message: Message, state: FSMContext, session: As
     try:
         amount = int(message.text)
     except ValueError:
-        await message.answer("Cantidad inválida. Ingresa un número.")
+        await send_temporary_reply(message, "Cantidad inválida. Ingresa un número.")
         return
     user_id = data.get("target_user")
     op = data.get("points_operation")
@@ -192,7 +192,7 @@ async def process_search_user(message: Message, state: FSMContext, session: Asyn
         users = result.scalars().all()
 
     if not users:
-        await message.answer("No se encontraron usuarios.")
+        await send_temporary_reply(message, "No se encontraron usuarios.")
     else:
         response = "Resultados:\n" + "\n".join(
             f"- {(u.username or u.first_name or 'Sin nombre')} (ID: {u.id})" for u in users

--- a/mybot/handlers/admin/subscription_plans.py
+++ b/mybot/handlers/admin/subscription_plans.py
@@ -9,6 +9,7 @@ from utils.user_roles import is_admin
 from utils.admin_state import AdminTariffStates
 from keyboards.tarifas_kb import get_duration_kb, get_tarifas_kb
 from keyboards.common import get_back_kb
+from utils.menu_utils import send_temporary_reply
 from database.models import Tariff
 from utils.text_utils import sanitize_text
 
@@ -65,7 +66,7 @@ async def tariff_price(message: Message, state: FSMContext):
     try:
         price = int(message.text)
     except ValueError:
-        await message.answer("Precio inválido. Ingresa un número.")
+        await send_temporary_reply(message, "Precio inválido. Ingresa un número.")
         return
     await state.update_data(price=price)
     await state.set_state(AdminTariffStates.waiting_for_tariff_name)

--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -26,7 +26,7 @@ from utils.text_utils import sanitize_text
 from utils.admin_state import AdminVipMessageStates, AdminManualBadgeStates
 from aiogram.fsm.context import FSMContext
 from database.models import Tariff
-from utils.menu_utils import update_menu
+from utils.menu_utils import update_menu, send_temporary_reply
 from database.models import set_user_menu_state
 
 router = Router()
@@ -152,12 +152,16 @@ async def process_manual_badge_user(message: Message, state: FSMContext, session
         result = await session.execute(stmt)
         user = result.scalar_one_or_none()
     if not user:
-        await message.answer("Usuario no encontrado. Intenta nuevamente:")
+        await send_temporary_reply(message, "Usuario no encontrado. Intenta nuevamente:")
         return
     await state.update_data(target_user=user.id)
     badges = await BadgeService(session).list_badges()
     if not badges:
-        await message.answer("No hay insignias disponibles.", reply_markup=get_back_keyboard("admin_vip"))
+        await send_temporary_reply(
+            message,
+            "No hay insignias disponibles.",
+            reply_markup=get_back_keyboard("admin_vip"),
+        )
         await state.clear()
         return
     builder = InlineKeyboardBuilder()

--- a/mybot/handlers/subscriptions.py
+++ b/mybot/handlers/subscriptions.py
@@ -10,6 +10,7 @@ from database.models import User
 from utils.text_utils import sanitize_text
 from services.config_service import ConfigService
 from services.achievement_service import AchievementService
+from utils.menu_utils import send_temporary_reply
 
 router = Router()
 
@@ -41,7 +42,7 @@ async def activate_vip(message: Message, session: AsyncSession, bot: Bot):
 
     subscription_duration = await validate_token(token, session)
     if not subscription_duration:
-        await message.answer("Token inválido o ya utilizado.")
+        await send_temporary_reply(message, "Token inválido o ya utilizado.")
         return
 
     user = await session.get(User, message.from_user.id)

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -9,6 +9,7 @@ from database.models import User
 from utils.text_utils import sanitize_text
 from services.token_service import TokenService
 from services.subscription_service import SubscriptionService
+from utils.menu_utils import send_temporary_reply
 from services.achievement_service import AchievementService
 from services.config_service import ConfigService
 
@@ -25,7 +26,7 @@ async def start_with_token(message: Message, command: CommandObject, session: As
     try:
         duration = await service.activate_token(token_string, message.from_user.id)
     except Exception:
-        await message.answer("Token inválido o ya utilizado.")
+        await send_temporary_reply(message, "Token inválido o ya utilizado.")
         return
 
     user = await session.get(User, message.from_user.id)


### PR DESCRIPTION
## Summary
- keep one menu message per user and reuse it
- temporary error messages delete themselves after a few seconds
- apply temporary messages to a few handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b769c9a083298ee73adc59e54d05