### PR TITLE
Add rewards claim system

### DIFF
--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -1,5 +1,10 @@
 # utils/keyboard_utils.py
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton, ReplyKeyboardMarkup, KeyboardButton
+from aiogram.types import (
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+)
 from database.models import User
 from utils.messages import BOT_MESSAGES
 
@@ -11,9 +16,10 @@ def get_main_menu_keyboard():
         [InlineKeyboardButton(text="👤 Perfil", callback_data="menu:profile")],
         [InlineKeyboardButton(text="🗺 Misiones", callback_data="menu:missions")],
         [InlineKeyboardButton(text="🎁 Recompensas", callback_data="menu:rewards")],
-        [InlineKeyboardButton(text="🏆 Ranking", callback_data="menu:ranking")]
+        [InlineKeyboardButton(text="🏆 Ranking", callback_data="menu:ranking")],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
 
 def get_profile_keyboard():
     """Returns the keyboard for the profile section."""
@@ -22,41 +28,80 @@ def get_profile_keyboard():
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
+
 def get_missions_keyboard(missions: list, offset: int = 0):
     """Returns the keyboard for missions, with pagination."""
     keyboard = []
     # Display up to 5 missions per page
-    for mission in missions[offset:offset+5]:
-        keyboard.append([InlineKeyboardButton(text=f"{mission.name} ({mission.reward_points} Pts)", callback_data=f"mission_{mission.id}")])
-    
+    for mission in missions[offset : offset + 5]:
+        keyboard.append(
+            [
+                InlineKeyboardButton(
+                    text=f"{mission.name} ({mission.reward_points} Pts)",
+                    callback_data=f"mission_{mission.id}",
+                )
+            ]
+        )
+
     # Add navigation buttons if there are more missions
     nav_buttons = []
     if offset > 0:
-        nav_buttons.append(InlineKeyboardButton(text="← Anterior", callback_data=f"missions_page_{offset - 5}"))
+        nav_buttons.append(
+            InlineKeyboardButton(
+                text="← Anterior", callback_data=f"missions_page_{offset - 5}"
+            )
+        )
     if offset + 5 < len(missions):
-        nav_buttons.append(InlineKeyboardButton(text="Siguiente →", callback_data=f"missions_page_{offset + 5}"))
+        nav_buttons.append(
+            InlineKeyboardButton(
+                text="Siguiente →", callback_data=f"missions_page_{offset + 5}"
+            )
+        )
     if nav_buttons:
         keyboard.append(nav_buttons)
 
-    keyboard.append([InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")])
+    keyboard.append(
+        [InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")]
+    )
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-def get_reward_keyboard(rewards: list):
-    """Returns the keyboard for rewards."""
+def get_reward_keyboard(
+    rewards: list, claimed_ids: set[int], offset: int = 0
+) -> InlineKeyboardMarkup:
+    """Return reward keyboard with pagination and claim status."""
+
     keyboard = []
-    for reward in rewards:
-        keyboard.append([InlineKeyboardButton(text=f"{reward.name} ({reward.cost} Pts)", callback_data=f"buy_reward_{reward.id}")])
-    keyboard.append([InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")])
+    for reward in rewards[offset : offset + 5]:
+        if reward.id in claimed_ids:
+            text = f"{reward.title} ✅"
+            callback = f"claimed_{reward.id}"
+        else:
+            text = f"{reward.title} ({reward.required_points} Pts)"
+            callback = f"claim_reward_{reward.id}"
+        keyboard.append([InlineKeyboardButton(text=text, callback_data=callback)])
+
+    nav_buttons = []
+    if offset > 0:
+        nav_buttons.append(
+            InlineKeyboardButton(
+                text="← Anterior", callback_data=f"rewards_page_{offset - 5}"
+            )
+        )
+    if offset + 5 < len(rewards):
+        nav_buttons.append(
+            InlineKeyboardButton(
+                text="Siguiente →", callback_data=f"rewards_page_{offset + 5}"
+            )
+        )
+    if nav_buttons:
+        keyboard.append(nav_buttons)
+
+    keyboard.append(
+        [InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")]
+    )
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
-def get_confirm_purchase_keyboard(reward_id: int):
-    """Returns the confirmation keyboard for reward purchase."""
-    keyboard = [
-        [InlineKeyboardButton(text="✅ Confirmar", callback_data=f"confirm_purchase_{reward_id}")],
-        [InlineKeyboardButton(text="❌ Cancelar", callback_data=f"cancel_purchase_{reward_id}")]
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 def get_ranking_keyboard():
     """Returns the keyboard for the ranking section."""
@@ -65,18 +110,29 @@ def get_ranking_keyboard():
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
-def get_reaction_keyboard(message_id: int, like_text: str = "👍 Me gusta", dislike_text: str = "👎 No me gusta"):
+
+def get_reaction_keyboard(
+    message_id: int,
+    like_text: str = "👍 Me gusta",
+    dislike_text: str = "👎 No me gusta",
+):
     """Return an inline keyboard with like/dislike buttons for channel posts."""
     keyboard = [
         [
-            InlineKeyboardButton(text=like_text, callback_data=f"reaction_like_{message_id}"),
-            InlineKeyboardButton(text=dislike_text, callback_data=f"reaction_dislike_{message_id}")
+            InlineKeyboardButton(
+                text=like_text, callback_data=f"reaction_like_{message_id}"
+            ),
+            InlineKeyboardButton(
+                text=dislike_text, callback_data=f"reaction_dislike_{message_id}"
+            ),
         ]
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-def get_custom_reaction_keyboard(message_id: int, buttons: list[str]) -> InlineKeyboardMarkup:
+def get_custom_reaction_keyboard(
+    message_id: int, buttons: list[str]
+) -> InlineKeyboardMarkup:
     """Return an inline keyboard using custom button texts for reactions."""
     if len(buttons) >= 2:
         like, dislike = buttons[0], buttons[1]
@@ -87,109 +143,265 @@ def get_custom_reaction_keyboard(message_id: int, buttons: list[str]) -> InlineK
 
 def get_admin_manage_users_keyboard():
     """Returns the keyboard for user management options in the admin panel."""
-    keyboard = InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="➕ Sumar Puntos a Usuario", callback_data="admin_add_points")],
-        [InlineKeyboardButton(text="➖ Restar Puntos a Usuario", callback_data="admin_deduct_points")],
-        [InlineKeyboardButton(text="🔍 Ver Perfil de Usuario", callback_data="admin_view_user")],
-        [InlineKeyboardButton(text="🔎 Buscar Usuario", callback_data="admin_search_user")],
-        [InlineKeyboardButton(text="📢 Notificar a Usuarios", callback_data="admin_notify_users")],
-        [InlineKeyboardButton(text="🔙 Volver al Menú Principal de Administrador", callback_data="admin_main_menu")]
-    ])
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="➕ Sumar Puntos a Usuario", callback_data="admin_add_points"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="➖ Restar Puntos a Usuario",
+                    callback_data="admin_deduct_points",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔍 Ver Perfil de Usuario", callback_data="admin_view_user"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔎 Buscar Usuario", callback_data="admin_search_user"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="📢 Notificar a Usuarios", callback_data="admin_notify_users"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver al Menú Principal de Administrador",
+                    callback_data="admin_main_menu",
+                )
+            ],
+        ]
+    )
     return keyboard
+
 
 def get_admin_manage_content_keyboard():
     """Returns the keyboard for content management options."""
-    keyboard = InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="👥 Gestionar Usuarios", callback_data="admin_manage_users")],
-        [InlineKeyboardButton(text="📌 Misiones", callback_data="admin_content_missions")],
-        [InlineKeyboardButton(text="🏅 Insignias", callback_data="admin_content_badges")],
-        [InlineKeyboardButton(text="📈 Niveles", callback_data="admin_content_levels")],
-        [InlineKeyboardButton(text="🎁 Recompensas (Catálogo VIP)", callback_data="admin_content_rewards")],
-        [InlineKeyboardButton(text="📦 Subastas", callback_data="admin_content_auctions")],
-        [InlineKeyboardButton(text="🎁 Regalos Diarios", callback_data="admin_content_daily_gifts")],
-        [InlineKeyboardButton(text="🕹 Minijuegos", callback_data="admin_content_minigames")],
-        [InlineKeyboardButton(text="🎉 Eventos y Sorteos", callback_data="admin_manage_events_sorteos")],
-        [InlineKeyboardButton(text="📝 Publicar en Canal", callback_data="admin_send_channel_post")],
-        [InlineKeyboardButton(text="🔙 Volver al Menú Principal de Administrador", callback_data="admin_main_menu")]
-    ])
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="👥 Gestionar Usuarios", callback_data="admin_manage_users"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="📌 Misiones", callback_data="admin_content_missions"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🏅 Insignias", callback_data="admin_content_badges"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="📈 Niveles", callback_data="admin_content_levels"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🎁 Recompensas (Catálogo VIP)",
+                    callback_data="admin_content_rewards",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="📦 Subastas", callback_data="admin_content_auctions"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🎁 Regalos Diarios", callback_data="admin_content_daily_gifts"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🕹 Minijuegos", callback_data="admin_content_minigames"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🎉 Eventos y Sorteos",
+                    callback_data="admin_manage_events_sorteos",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="📝 Publicar en Canal", callback_data="admin_send_channel_post"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver al Menú Principal de Administrador",
+                    callback_data="admin_main_menu",
+                )
+            ],
+        ]
+    )
     return keyboard
+
 
 def get_admin_content_missions_keyboard():
     """Keyboard for mission management options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="➕ Crear Misión", callback_data="admin_create_mission")],
-            [InlineKeyboardButton(text="✅/❌ Activar/Desactivar", callback_data="admin_toggle_mission")],
-            [InlineKeyboardButton(text="👁 Ver Activas", callback_data="admin_view_missions")],
-            [InlineKeyboardButton(text="🗑 Eliminar", callback_data="admin_delete_mission")],
-            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
+            [
+                InlineKeyboardButton(
+                    text="➕ Crear Misión", callback_data="admin_create_mission"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="✅/❌ Activar/Desactivar",
+                    callback_data="admin_toggle_mission",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="👁 Ver Activas", callback_data="admin_view_missions"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🗑 Eliminar", callback_data="admin_delete_mission"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver", callback_data="admin_manage_content"
+                )
+            ],
         ]
     )
     return keyboard
+
 
 def get_admin_content_badges_keyboard():
     """Keyboard for badge management options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="Bot\u00f3n de prueba", callback_data="admin_game_test")],
-            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
+            [
+                InlineKeyboardButton(
+                    text="Bot\u00f3n de prueba", callback_data="admin_game_test"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver", callback_data="admin_manage_content"
+                )
+            ],
         ]
     )
     return keyboard
+
 
 def get_admin_content_levels_keyboard():
     """Keyboard for level management options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="Bot\u00f3n de prueba", callback_data="admin_game_test")],
-            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
+            [
+                InlineKeyboardButton(
+                    text="Bot\u00f3n de prueba", callback_data="admin_game_test"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver", callback_data="admin_manage_content"
+                )
+            ],
         ]
     )
     return keyboard
+
 
 def get_admin_content_rewards_keyboard():
     """Keyboard for reward catalogue management options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="Bot\u00f3n de prueba", callback_data="admin_game_test")],
-            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
+            [
+                InlineKeyboardButton(
+                    text="Bot\u00f3n de prueba", callback_data="admin_game_test"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver", callback_data="admin_manage_content"
+                )
+            ],
         ]
     )
     return keyboard
+
 
 def get_admin_content_auctions_keyboard():
     """Keyboard for auction management options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="Bot\u00f3n de prueba", callback_data="admin_game_test")],
-            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
+            [
+                InlineKeyboardButton(
+                    text="Bot\u00f3n de prueba", callback_data="admin_game_test"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver", callback_data="admin_manage_content"
+                )
+            ],
         ]
     )
     return keyboard
+
 
 def get_admin_content_daily_gifts_keyboard():
     """Keyboard for daily gift configuration options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="Bot\u00f3n de prueba", callback_data="admin_game_test")],
-            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
+            [
+                InlineKeyboardButton(
+                    text="Bot\u00f3n de prueba", callback_data="admin_game_test"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver", callback_data="admin_manage_content"
+                )
+            ],
         ]
     )
     return keyboard
+
 
 def get_admin_content_minigames_keyboard():
     """Keyboard placeholder for minigames options."""
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="Bot\u00f3n de prueba", callback_data="admin_game_test")],
-            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
+            [
+                InlineKeyboardButton(
+                    text="Bot\u00f3n de prueba", callback_data="admin_game_test"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="🔙 Volver", callback_data="admin_manage_content"
+                )
+            ],
         ]
     )
     return keyboard
 
+
 # --- Funciones para la navegación de menú ---
 # Estas funciones están más orientadas a la lógica de estado que a la creación de teclados per se,
 # pero se mantienen aquí para compatibilidad si las usas para generar teclados dinámicos.
+
 
 def get_root_menu():
     """Returns the inline keyboard for the root menu."""
@@ -197,7 +409,7 @@ def get_root_menu():
         [InlineKeyboardButton(text="👤 Perfil", callback_data="menu:profile")],
         [InlineKeyboardButton(text="🗺 Misiones", callback_data="menu:missions")],
         [InlineKeyboardButton(text="🎁 Recompensas", callback_data="menu:rewards")],
-        [InlineKeyboardButton(text="🏆 Ranking", callback_data="menu:ranking")]
+        [InlineKeyboardButton(text="🏆 Ranking", callback_data="menu:ranking")],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
@@ -207,9 +419,11 @@ def get_parent_menu(parent_name: str):
     if parent_name == "profile":
         return get_profile_keyboard()
     elif parent_name == "missions":
-        return get_missions_keyboard([])  # Puedes adaptar esto si quieres mostrar misiones
+        return get_missions_keyboard(
+            []
+        )  # Puedes adaptar esto si quieres mostrar misiones
     elif parent_name == "rewards":
-        return get_reward_keyboard([])
+        return get_reward_keyboard([], set())
     elif parent_name == "ranking":
         return get_ranking_keyboard()
     else:
@@ -223,11 +437,12 @@ def get_child_menu(menu_name: str):
     elif menu_name == "missions":
         return get_missions_keyboard([])
     elif menu_name == "rewards":
-        return get_reward_keyboard([])
+        return get_reward_keyboard([], set())
     elif menu_name == "ranking":
         return get_ranking_keyboard()
     else:
         return get_root_menu()
+
 
 def get_main_reply_keyboard():
     """
@@ -236,26 +451,18 @@ def get_main_reply_keyboard():
     """
     keyboard = ReplyKeyboardMarkup(
         keyboard=[
-            [
-                KeyboardButton(text="👤 Perfil"),
-                KeyboardButton(text="🗺 Misiones")
-            ],
-            [
-                KeyboardButton(text="🎁 Recompensas"),
-                KeyboardButton(text="🏆 Ranking")
-            ]
+            [KeyboardButton(text="👤 Perfil"), KeyboardButton(text="🗺 Misiones")],
+            [KeyboardButton(text="🎁 Recompensas"), KeyboardButton(text="🏆 Ranking")],
         ],
-        resize_keyboard=True, # Make the keyboard smaller
-        one_time_keyboard=False # Keep the keyboard visible
+        resize_keyboard=True,  # Make the keyboard smaller
+        one_time_keyboard=False,  # Keep the keyboard visible
     )
     return keyboard
 
 
 def get_back_keyboard(callback_data: str) -> InlineKeyboardMarkup:
     """Return a simple keyboard with a single back button."""
-    keyboard = [
-        [InlineKeyboardButton(text="🔙 Volver", callback_data=callback_data)]
-    ]
+    keyboard = [[InlineKeyboardButton(text="🔙 Volver", callback_data=callback_data)]]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
@@ -309,7 +516,9 @@ def get_admin_users_list_keyboard(
     if nav_buttons:
         keyboard.append(nav_buttons)
 
-    keyboard.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_main_menu")])
+    keyboard.append(
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_main_menu")]
+    )
 
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
@@ -318,6 +527,10 @@ def get_badge_selection_keyboard(badges: list) -> InlineKeyboardMarkup:
     rows = []
     for b in badges:
         label = f"{b.emoji or ''} {b.name}".strip()
-        rows.append([InlineKeyboardButton(text=label, callback_data=f"select_badge_{b.id}")])
-    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_content_badges")])
+        rows.append(
+            [InlineKeyboardButton(text=label, callback_data=f"select_badge_{b.id}")]
+        )
+    rows.append(
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_content_badges")]
+    )
     return InlineKeyboardMarkup(inline_keyboard=rows)

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -7,23 +7,24 @@ from services.achievement_service import ACHIEVEMENTS
 from utils.messages import BOT_MESSAGES
 import datetime
 
-async def get_profile_message(user: User, active_missions: list[Mission], session: AsyncSession) -> str:
+
+async def get_profile_message(
+    user: User, active_missions: list[Mission], session: AsyncSession
+) -> str:
     points_to_next_level_text = ""
     level_service = LevelService(session)
     next_level_threshold = await level_service.get_level_threshold(user.level + 1)
-    if next_level_threshold != float('inf'):
+    if next_level_threshold != float("inf"):
         points_needed = next_level_threshold - user.points
         # Usar el mensaje personalizado para puntos al siguiente nivel
         points_to_next_level_text = BOT_MESSAGES["profile_points_to_next_level"].format(
             points_needed=points_needed,
             next_level=user.level + 1,
-            next_level_threshold=next_level_threshold
+            next_level_threshold=next_level_threshold,
         )
     else:
         # Usar el mensaje personalizado para nivel máximo
         points_to_next_level_text = BOT_MESSAGES["profile_max_level"]
-
-
 
     # Usar el mensaje personalizado para no logros
     achievements_text = BOT_MESSAGES["profile_no_achievements"]
@@ -35,12 +36,14 @@ async def get_profile_message(user: User, active_missions: list[Mission], sessio
         for rec in records:
             ach_data = ACHIEVEMENTS.get(rec.achievement_id)
             if ach_data:
-                granted_achievements_list.append({
-                    "id": rec.achievement_id,
-                    "name": ach_data.get("name", rec.achievement_id),
-                    "icon": ach_data.get("icon", ""),
-                    "granted_at": rec.unlocked_at.isoformat(),
-                })
+                granted_achievements_list.append(
+                    {
+                        "id": rec.achievement_id,
+                        "name": ach_data.get("name", rec.achievement_id),
+                        "icon": ach_data.get("icon", ""),
+                        "granted_at": rec.unlocked_at.isoformat(),
+                    }
+                )
         granted_achievements_list.sort(key=lambda x: x["granted_at"])
 
         achievements_list = [
@@ -48,7 +51,9 @@ async def get_profile_message(user: User, active_missions: list[Mission], sessio
             for ach in granted_achievements_list
         ]
         achievements_text = (
-            BOT_MESSAGES["profile_achievements_title"] + "\n" + "\n".join(achievements_list)
+            BOT_MESSAGES["profile_achievements_title"]
+            + "\n"
+            + "\n".join(achievements_list)
         )
 
     # Usar el mensaje personalizado para no misiones activas
@@ -58,7 +63,11 @@ async def get_profile_message(user: User, active_missions: list[Mission], sessio
             f"• {mission.name} ({mission.reward_points} Puntos)"
             for mission in active_missions
         ]
-        missions_text = BOT_MESSAGES["profile_active_missions_title"] + "\n" + "\n".join(missions_list)
+        missions_text = (
+            BOT_MESSAGES["profile_active_missions_title"]
+            + "\n"
+            + "\n".join(missions_list)
+        )
 
     return (
         # Usar mensajes personalizados para cada parte del perfil
@@ -66,9 +75,10 @@ async def get_profile_message(user: User, active_missions: list[Mission], sessio
         f"{BOT_MESSAGES['profile_points'].format(user_points=user.points)}\n"
         f"{BOT_MESSAGES['profile_level'].format(user_level=user.level)}\n"
         f"{points_to_next_level_text}\n\n"
-        f"{achievements_text}\n\n" # Incluye el título de logros
-        f"{missions_text}" # Incluye el título de misiones
+        f"{achievements_text}\n\n"  # Incluye el título de logros
+        f"{missions_text}"  # Incluye el título de misiones
     )
+
 
 async def get_mission_details_message(mission: Mission) -> str:
     # Usar el mensaje personalizado para detalles de misión
@@ -76,23 +86,19 @@ async def get_mission_details_message(mission: Mission) -> str:
         mission_name=mission.name,
         mission_description=mission.description,
         points_reward=mission.reward_points,
-        mission_type=mission.type.capitalize()
+        mission_type=mission.type.capitalize(),
     )
+
 
 async def get_reward_details_message(reward: Reward, user_points: int) -> str:
-    stock_info = ""
-    if reward.stock != -1:
-        stock_info = BOT_MESSAGES["reward_details_stock_info"].format(stock_left=reward.stock)
-    else:
-        stock_info = BOT_MESSAGES["reward_details_no_stock_info"]
+    """Return a formatted description of a reward."""
 
-    # Usar el mensaje personalizado para detalles de recompensa
     return BOT_MESSAGES["reward_details_text"].format(
-        reward_name=reward.name,
+        reward_title=reward.title,
         reward_description=reward.description,
-        reward_cost=reward.cost,
-        stock_info=stock_info
+        required_points=reward.required_points,
     )
+
 
 async def get_ranking_message(users_ranking: list[User]) -> str:
     """
@@ -106,13 +112,17 @@ async def get_ranking_message(users_ranking: list[User]) -> str:
     for i, user in enumerate(users_ranking):
         # Format each user entry
         # Usa user.username si está disponible, de lo contrario, user.first_name
-        display_name = user.username if user.username else user.first_name if user.first_name else "Usuario Desconocido"
-        ranking_text += BOT_MESSAGES["ranking_entry"].format(
-            rank=i + 1,
-            username=display_name,
-            points=user.points,
-            level=user.level
-        ) + "\n"
+        display_name = (
+            user.username
+            if user.username
+            else user.first_name if user.first_name else "Usuario Desconocido"
+        )
+        ranking_text += (
+            BOT_MESSAGES["ranking_entry"].format(
+                rank=i + 1, username=display_name, points=user.points, level=user.level
+            )
+            + "\n"
+        )
 
     return ranking_text
 
@@ -123,4 +133,3 @@ async def get_mission_completed_message(mission: Mission) -> str:
         mission_name=mission.name,
         points_reward=mission.reward_points,
     )
-

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -33,21 +33,18 @@ BOT_MESSAGES = {
     "reward_shop_empty": "Por ahora no hay recompensas disponibles. Pero pronto sí. 😉",
     "reward_not_found": "Esa recompensa ya no está aquí... o aún no está lista.",
     "reward_not_registered": "Tu perfil no está activo. Usa /start para comenzar *El Juego del Diván*.",
-    "reward_out_of_stock": "Esa recompensa ya se fue. Las cosas buenas no esperan.",
     "reward_not_enough_points": "Te faltan `{required_points}` puntos. Ahora tienes `{user_points}`. Pero sigue... estás cerca.",
-    "reward_purchase_success": "🎉 ¡Recompensa conseguida! Algo bonito está por llegar.",
-    "reward_purchase_failed": "No pudimos procesar tu elección. Inténtalo más tarde.",
-
+    "reward_claim_success": "🎉 ¡Recompensa reclamada!",
+    "reward_claim_failed": "No pudimos procesar tu solicitud.",
+    "reward_already_claimed": "Esta recompensa ya fue reclamada.",
     # Niveles
     "level_up_notification": "🎉 ¡Subiste a Nivel {level}: {level_name}! {reward}",
     "special_level_reward": "✨ Recompensa especial por alcanzar el nivel {level}! {reward}",
-
     # Mensajes de ranking (Unificados)
     "ranking_title": "🏆 *Tabla de Posiciones*",
     "ranking_entry": "#{rank}. @{username} - Puntos: `{points}`, Nivel: `{level}`",
     "no_ranking_data": "Aún no hay datos en el ranking. ¡Sé el primero en aparecer!",
     "back_to_main_menu": "Has regresado al centro del Diván. Elige por dónde seguir explorando.",
-
     # Botones
     "profile_achievements_button_text": "🏅 Mis Logros",
     "profile_active_missions_button_text": "🎯 Mis Desafíos",
@@ -61,7 +58,6 @@ BOT_MESSAGES = {
     "prev_page_button_text": "← Anterior",
     "next_page_button_text": "Siguiente →",
     "back_to_main_menu_button_text": "← Volver al inicio",
-
     # Detalles
     "mission_details_text": (
         "🎯 *Desafío:* {mission_name}\n\n"
@@ -70,15 +66,11 @@ BOT_MESSAGES = {
         "⏱️ *Frecuencia:* `{mission_type}`"
     ),
     "reward_details_text": (
-        "🎁 *Recompensa:* {reward_name}\n\n"
+        "🎁 *Recompensa:* {reward_title}\n\n"
         "📌 *Descripción:* {reward_description}\n"
-        "💰 *Costo:* `{reward_cost}` puntos\n"
-        "{stock_info}"
+        "🔥 *Requiere:* `{required_points}` puntos"
     ),
-    "reward_details_stock_info": "📦 *Disponibles:* `{stock_left}`",
-    "reward_details_no_stock_info": "📦 *Disponibles:* ilimitadas",
     "reward_details_not_enough_points_alert": "💔 Te faltan puntos para esta recompensa. Necesitas `{required_points}`, tienes `{user_points}`. Sigue sumando, lo estás haciendo bien.",
-
     # Mensajes adicionales que eran mencionados en user_handlers.py
     "menu_missions_text": "Aquí están los desafíos que puedes emprender. ¡Cada uno te acerca más!",
     "menu_rewards_text": "¡Es hora de canjear tus puntos! Aquí tienes las recompensas disponibles:",
@@ -96,11 +88,9 @@ BOT_MESSAGES = {
     "trivia_correct": "¡Correcto! +5 puntos",
     "trivia_wrong": "Respuesta incorrecta.",
     "unrecognized_command_text": "Comando no reconocido. Aquí está el menú principal:",
-
     # Notificaciones de gamificación
     "challenge_completed": "🎯 ¡Desafío {challenge_type} completado! +{points} puntos",
     "reaction_registered": "👍 ¡Reacción registrada!",
-
     # --- Administración de Recompensas ---
     "enter_reward_name": "Ingresa el nombre de la recompensa:",
     "enter_reward_description": "Describe brevemente la recompensa:",


### PR DESCRIPTION
## Summary
- define new Reward and UserReward models
- implement RewardService with reward claiming logic
- update keyboards and gamification handlers for rewards
- allow /rewards command and inline claim flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ba0c8b908329b17dcff9d3e231fa