### PR TITLE
Fix VIP channel posting and tidy admin menu

### DIFF
--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from aiogram import Bot
 from aiogram.types import Message
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .config_service import ConfigService
@@ -36,13 +37,18 @@ class MessageService:
         if not channel_id:
             return None
 
-        sent = await self.bot.send_message(
-            channel_id, text, reply_markup=get_interactive_post_kb(0)
-        )
-        await self.bot.edit_message_reply_markup(
-            channel_id, sent.message_id, reply_markup=get_interactive_post_kb(sent.message_id)
-        )
-        return sent
+        try:
+            sent = await self.bot.send_message(
+                channel_id, text, reply_markup=get_interactive_post_kb(0)
+            )
+            await self.bot.edit_message_reply_markup(
+                channel_id,
+                sent.message_id,
+                reply_markup=get_interactive_post_kb(sent.message_id),
+            )
+            return sent
+        except (TelegramBadRequest, TelegramForbiddenError, TelegramAPIError):
+            return None
 
     async def register_reaction(
         self, user_id: int, message_id: int, reaction_type: str

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -235,11 +235,6 @@ def get_admin_manage_content_keyboard():
             ],
             [
                 InlineKeyboardButton(
-                    text="📝 Publicar en Canal", callback_data="admin_send_channel_post"
-                )
-            ],
-            [
-                InlineKeyboardButton(
                     text="🔙 Volver al Menú Principal de Administrador",
                     callback_data="admin_main_menu",
                 )


### PR DESCRIPTION
## Summary
- remove duplicate *Publicar en Canal* button from the game admin menu
- handle Telegram API errors when sending interactive posts to the VIP channel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68519149cc9c8329a769e34e3937f079