### PR TITLE
Fix VIP channel post error message

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -225,10 +225,16 @@ async def process_vip_channel_post(message: Message, state: FSMContext, session:
         return
     service = MessageService(session, bot)
     sent = await service.send_interactive_post(message.text, "vip")
-    if not sent:
+    if sent is None:
         await send_clean_message(
             message,
             "Canal VIP no configurado.",
+            reply_markup=get_admin_vip_kb(),
+        )
+    elif sent is False:
+        await send_clean_message(
+            message,
+            "No se pudo publicar en el canal. Revisa los permisos del bot.",
             reply_markup=get_admin_vip_kb(),
         )
     else:

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -20,8 +20,13 @@ class MessageService:
         self,
         text: str,
         channel_type: str = "vip",
-    ) -> Message | None:
-        """Send a message with interactive buttons to the configured channel."""
+    ) -> Message | bool | None:
+        """Send a message with interactive buttons to the configured channel.
+
+        Returns the ``Message`` object on success, ``None`` when the channel
+        isn't configured and ``False`` if sending fails due to Telegram
+        errors.
+        """
         config = ConfigService(self.session)
         channel_type = channel_type.lower()
         if channel_type == "vip":
@@ -48,7 +53,7 @@ class MessageService:
             )
             return sent
         except (TelegramBadRequest, TelegramForbiddenError, TelegramAPIError):
-            return None
+            return False
 
     async def register_reaction(
         self, user_id: int, message_id: int, reaction_type: str


### PR DESCRIPTION
## Summary
- clarify return values for `send_interactive_post` to differentiate configuration issues from Telegram errors
- show a specific error in the admin VIP menu when posting fails due to permissions

## Testing
- `python -m py_compile mybot/services/message_service.py mybot/handlers/admin/vip_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_68519c9b5c308329b8330c7cb6a2c197