### PR TITLE
Fix VIP posting reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 | `VIP_POINTS_MULTIPLIER` | Points multiplier applied when a VIP user earns points |
 | `CHANNEL_SCHEDULER_INTERVAL` | Seconds between checks for channel requests. Defaults to `30` |
 | `VIP_SCHEDULER_INTERVAL` | Seconds between VIP subscription checks. Defaults to `3600` |
+| `REACTION_BUTTONS` | Semicolon separated texts for reaction buttons used on channel posts |
 
 3. Initialise the database and populate base data (tables, achievements,
    levels and some starter missions). Run this command once after configuring
@@ -107,6 +108,8 @@ Acceso a la gestión de canales (VIP y free)
 Acceso al módulo de juego (gamificación)
 
 Configuraciones generales y de seguridad
+
+Personalización de los textos de reacción que acompañan las publicaciones de canal
 
 Sección de estadísticas del bot
 

--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -1,6 +1,8 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import InlineKeyboardMarkup
 
+from utils.config import DEFAULT_REACTION_BUTTONS
+
 
 def get_back_kb(callback_data: str = "admin_back"):
     builder = InlineKeyboardBuilder()
@@ -9,11 +11,16 @@ def get_back_kb(callback_data: str = "admin_back"):
     return builder.as_markup()
 
 
-def get_interactive_post_kb(message_id: int) -> InlineKeyboardMarkup:
-    """Keyboard with Like/Share/Fire buttons for channel posts."""
+def get_interactive_post_kb(
+    message_id: int, buttons: list[str] | None = None
+) -> InlineKeyboardMarkup:
+    """Keyboard with reaction buttons for channel posts."""
+    texts = (
+        buttons if buttons and len(buttons) >= 3 else DEFAULT_REACTION_BUTTONS
+    )
     builder = InlineKeyboardBuilder()
-    builder.button(text="👍 Me gusta", callback_data=f"ip_like_{message_id}")
-    builder.button(text="🔁 Compartir", callback_data=f"ip_share_{message_id}")
-    builder.button(text="🔥 Sexy", callback_data=f"ip_fire_{message_id}")
+    builder.button(text=texts[0], callback_data=f"ip_like_{message_id}")
+    builder.button(text=texts[1], callback_data=f"ip_share_{message_id}")
+    builder.button(text=texts[2], callback_data=f"ip_fire_{message_id}")
     builder.adjust(3)
     return builder.as_markup()

--- a/mybot/services/config_service.py
+++ b/mybot/services/config_service.py
@@ -9,6 +9,7 @@ from utils.text_utils import sanitize_text
 class ConfigService:
     VIP_CHANNEL_KEY = "VIP_CHANNEL_ID"
     FREE_CHANNEL_KEY = "FREE_CHANNEL_ID"
+    REACTION_BUTTONS_KEY = "reaction_buttons"
 
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -49,4 +50,15 @@ class ConfigService:
 
     async def set_free_channel_id(self, chat_id: int) -> ConfigEntry:
         return await self.set_value(self.FREE_CHANNEL_KEY, str(chat_id))
+
+    async def get_reaction_buttons(self) -> list[str]:
+        """Return custom reaction button texts or defaults."""
+        value = await self.get_value(self.REACTION_BUTTONS_KEY)
+        if value:
+            texts = [t.strip() for t in value.split(";") if t.strip()]
+            if len(texts) >= 3:
+                return texts[:3]
+        from utils.config import DEFAULT_REACTION_BUTTONS
+
+        return DEFAULT_REACTION_BUTTONS
 

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -43,13 +43,14 @@ class MessageService:
             return None
 
         try:
+            buttons = await config.get_reaction_buttons()
             sent = await self.bot.send_message(
-                channel_id, text, reply_markup=get_interactive_post_kb(0)
+                channel_id, text, reply_markup=get_interactive_post_kb(0, buttons)
             )
             await self.bot.edit_message_reply_markup(
                 channel_id,
                 sent.message_id,
-                reply_markup=get_interactive_post_kb(sent.message_id),
+                reply_markup=get_interactive_post_kb(sent.message_id, buttons),
             )
             return sent
         except (TelegramBadRequest, TelegramForbiddenError, TelegramAPIError):

--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -43,6 +43,10 @@ FREE_CHANNEL_ID = int(os.environ.get("FREE_CHANNEL_ID", "0"))
 CHANNEL_SCHEDULER_INTERVAL = int(os.environ.get("CHANNEL_SCHEDULER_INTERVAL", "30"))
 VIP_SCHEDULER_INTERVAL = int(os.environ.get("VIP_SCHEDULER_INTERVAL", "3600"))
 
+# Default reaction button texts used on channel posts when no custom values
+# are configured via the admin settings menu.
+DEFAULT_REACTION_BUTTONS = ["👍 Me gusta", "🔁 Compartir", "🔥 Sexy"]
+
 class Config:
     BOT_TOKEN = BOT_TOKEN
     ADMIN_ID = ADMIN_IDS[0] if ADMIN_IDS else 0


### PR DESCRIPTION
## Summary
- allow customizing reaction buttons in config
- show bullet in README about customizing reactions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851a0e8be14832999e41e8b13ed08b1