### PR TITLE
Add confirmation for channel posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/__pycache__/
+*.pyc
+*.pyo

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@
 | `VIP_SCHEDULER_INTERVAL` | Seconds between VIP subscription checks. Defaults to `3600` |
 | `REACTION_BUTTONS` | Semicolon separated texts for reaction buttons used on channel posts |
 
+### Customising reaction buttons
+
+The texts shown below channel posts can be changed at runtime. Open the admin
+menu, choose **Configuración** and then **📝 Configurar Reacciones**. Send the
+three button labels separated by `;` (for example: `👍 Me gusta;🔁 Compartir;🔥 Sexy`).
+You can also set initial values using the `REACTION_BUTTONS` environment
+variable or by editing the `DEFAULT_REACTION_BUTTONS` list in
+`mybot/utils/config.py`.
+
 3. Initialise the database and populate base data (tables, achievements,
    levels and some starter missions). Run this command once after configuring
    the environment:

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -54,6 +54,7 @@ class AdminContentStates(StatesGroup):
     """States related to posting content to channels."""
 
     waiting_for_channel_post_text = State()
+    confirming_channel_post = State()
 
 
 class AdminConfigStates(StatesGroup):

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -483,6 +483,15 @@ def get_back_keyboard(callback_data: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
+def get_post_confirmation_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard used to confirm publishing a channel post."""
+    keyboard = [
+        [InlineKeyboardButton(text="✅ Publicar", callback_data="confirm_channel_post")],
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_vip")],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
 def get_reward_type_keyboard() -> InlineKeyboardMarkup:
     """Keyboard to select reward type."""
     keyboard = InlineKeyboardMarkup(


### PR DESCRIPTION
## Summary
- add confirm step before sending channel posts in admin menu
- document how to customise reaction buttons
- provide keyboard for confirming posts
- ignore Python cache files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851a536bd088329a46b633b76caad1c