### PR TITLE
Improve reaction configuration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@
 
 ### Customising reaction buttons
 
-The texts shown below channel posts can be changed at runtime. Open the admin
-menu, choose **Configuración** and then **📝 Configurar Reacciones**. Send the
-three button labels separated by `;` (for example: `👍 Me gusta;🔁 Compartir;🔥 Sexy`).
+The emojis shown below channel posts can be changed at runtime. Open the admin
+menu, choose **Configuración** and then **📝 Configurar Reacciones**. The bot
+asks for each reaction emoji individually (up to ten). When finished, press
+**Aceptar** to save the configuration.
 You can also set initial values using the `REACTION_BUTTONS` environment
 variable or by editing the `DEFAULT_REACTION_BUTTONS` list in
 `mybot/utils/config.py`.

--- a/mybot/handlers/interactive_post.py
+++ b/mybot/handlers/interactive_post.py
@@ -14,7 +14,7 @@ async def handle_interactive_post_callback(
     parts = callback.data.split("_")
     if len(parts) < 3:
         return await callback.answer()
-    reaction_type = parts[1]
+    reaction_type = parts[1]  # e.g. 'r0'
     try:
         message_id = int(parts[2])
     except ValueError:

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -41,3 +41,12 @@ def get_config_done_kb():
     builder.button(text="Regresar al menú anterior", callback_data="admin_back")
     builder.adjust(1)
     return builder.as_markup()
+
+
+def get_reaction_confirm_kb():
+    """Keyboard shown while configuring reaction emojis."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="✅ Aceptar", callback_data="save_reactions")
+    builder.button(text="🔙 Volver", callback_data="admin_config")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -15,12 +15,9 @@ def get_interactive_post_kb(
     message_id: int, buttons: list[str] | None = None
 ) -> InlineKeyboardMarkup:
     """Keyboard with reaction buttons for channel posts."""
-    texts = (
-        buttons if buttons and len(buttons) >= 3 else DEFAULT_REACTION_BUTTONS
-    )
+    texts = buttons if buttons else DEFAULT_REACTION_BUTTONS
     builder = InlineKeyboardBuilder()
-    builder.button(text=texts[0], callback_data=f"ip_like_{message_id}")
-    builder.button(text=texts[1], callback_data=f"ip_share_{message_id}")
-    builder.button(text=texts[2], callback_data=f"ip_fire_{message_id}")
-    builder.adjust(3)
+    for idx, text in enumerate(texts[:10]):
+        builder.button(text=text, callback_data=f"ip_r{idx}_{message_id}")
+    builder.adjust(len(texts[:10]))
     return builder.as_markup()

--- a/mybot/services/config_service.py
+++ b/mybot/services/config_service.py
@@ -56,8 +56,8 @@ class ConfigService:
         value = await self.get_value(self.REACTION_BUTTONS_KEY)
         if value:
             texts = [t.strip() for t in value.split(";") if t.strip()]
-            if len(texts) >= 3:
-                return texts[:3]
+            if texts:
+                return texts[:10]
         from utils.config import DEFAULT_REACTION_BUTTONS
 
         return DEFAULT_REACTION_BUTTONS


### PR DESCRIPTION
## Summary
- allow configuring up to ten reaction emojis sequentially
- add keyboard for confirming reaction setup
- update interactive post keyboard and reaction handling to support variable number of buttons
- document updated flow in README

## Testing
- `python -m py_compile mybot/handlers/admin/config_menu.py mybot/keyboards/admin_config_kb.py mybot/keyboards/common.py mybot/services/config_service.py mybot/handlers/interactive_post.py`

------
https://chatgpt.com/codex/tasks/task_e_6851a7e6686c8329b1c6fdb24a4f4c43