### PR TITLE
Add VIP message reaction configuration

### DIFF
--- a/mybot/handlers/admin/config_menu.py
+++ b/mybot/handlers/admin/config_menu.py
@@ -50,6 +50,19 @@ async def prompt_reaction_buttons(callback: CallbackQuery, session: AsyncSession
     await callback.answer()
 
 
+@router.callback_query(F.data == "config_vip_reactions")
+async def prompt_vip_reactions(callback: CallbackQuery, session: AsyncSession, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Please send the first emoji to use as a reaction.",
+        reply_markup=get_back_keyboard("admin_config"),
+    )
+    await state.update_data(vip_reactions=[])
+    await state.set_state(AdminConfigStates.waiting_for_vip_reactions)
+    await callback.answer()
+
+
 @router.message(AdminConfigStates.waiting_for_reaction_buttons)
 async def set_reaction_buttons(message: Message, state: FSMContext, session: AsyncSession):
     if not is_admin(message.from_user.id):
@@ -71,6 +84,27 @@ async def set_reaction_buttons(message: Message, state: FSMContext, session: Asy
     await message.answer(text, reply_markup=get_reaction_confirm_kb())
 
 
+@router.message(AdminConfigStates.waiting_for_vip_reactions)
+async def set_vip_reactions(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    reactions = data.get("vip_reactions", [])
+    if len(reactions) >= 5:
+        await message.answer(
+            "❌ Only 5 reactions are allowed. Press Accept to confirm your selection.",
+            reply_markup=get_reaction_confirm_kb(),
+        )
+        return
+    reactions.append(message.text.strip())
+    await state.update_data(vip_reactions=reactions)
+    if len(reactions) >= 5:
+        text = f"✅ Reaction received: {message.text.strip()}"
+    else:
+        text = f"✅ Reaction received: {message.text.strip()}\nSend another emoji or press Accept to confirm."
+    await message.answer(text, reply_markup=get_reaction_confirm_kb())
+
+
 @router.callback_query(AdminConfigStates.waiting_for_reaction_buttons, F.data == "save_reactions")
 async def save_reaction_buttons_callback(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
     if not is_admin(callback.from_user.id):
@@ -84,6 +118,24 @@ async def save_reaction_buttons_callback(callback: CallbackQuery, state: FSMCont
     await service.set_value("reaction_buttons", ";".join(reactions))
     await callback.message.edit_text(
         "Botones de reacción actualizados.", reply_markup=get_admin_config_kb()
+    )
+    await state.clear()
+    await callback.answer()
+
+
+@router.callback_query(AdminConfigStates.waiting_for_vip_reactions, F.data == "save_reactions")
+async def save_vip_reactions_callback(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    data = await state.get_data()
+    reactions = data.get("vip_reactions", [])
+    if not reactions:
+        await callback.answer("Debes ingresar al menos una reacción.", show_alert=True)
+        return
+    service = ConfigService(session)
+    await service.set_vip_reactions(reactions)
+    await callback.message.edit_text(
+        "👍 Reactions saved successfully.", reply_markup=get_admin_config_kb()
     )
     await state.clear()
     await callback.answer()

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -4,6 +4,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_admin_config_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="📝 Configurar Reacciones", callback_data="config_reaction_buttons")
+    builder.button(text="🤖 Reacciones VIP", callback_data="config_vip_reactions")
     builder.button(text="➕ Agregar canales", callback_data="config_add_channels")
     builder.button(text="⏱️ Schedulers", callback_data="config_scheduler")
     builder.button(text="🔙 Volver", callback_data="admin_back")

--- a/mybot/services/config_service.py
+++ b/mybot/services/config_service.py
@@ -10,6 +10,7 @@ class ConfigService:
     VIP_CHANNEL_KEY = "VIP_CHANNEL_ID"
     FREE_CHANNEL_KEY = "FREE_CHANNEL_ID"
     REACTION_BUTTONS_KEY = "reaction_buttons"
+    VIP_REACTIONS_KEY = "vip_message_reactions"
 
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -61,4 +62,16 @@ class ConfigService:
         from utils.config import DEFAULT_REACTION_BUTTONS
 
         return DEFAULT_REACTION_BUTTONS
+
+    async def get_vip_reactions(self) -> list[str]:
+        """Return the list of default VIP message reactions."""
+        value = await self.get_value(self.VIP_REACTIONS_KEY)
+        if value:
+            emojis = [e.strip() for e in value.split(";") if e.strip()]
+            return emojis[:5]
+        return []
+
+    async def set_vip_reactions(self, reactions: list[str]) -> ConfigEntry:
+        """Store the default VIP message reactions as a semicolon string."""
+        return await self.set_value(self.VIP_REACTIONS_KEY, ";".join(reactions))
 

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from aiogram import Bot
-from aiogram.types import Message
+from aiogram.types import Message, ReactionTypeEmoji
 from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -52,6 +52,14 @@ class MessageService:
                 sent.message_id,
                 reply_markup=get_interactive_post_kb(sent.message_id, buttons),
             )
+            if channel_type == "vip":
+                vip_reactions = await config.get_vip_reactions()
+                if vip_reactions:
+                    await self.bot.set_message_reaction(
+                        channel_id,
+                        sent.message_id,
+                        [ReactionTypeEmoji(emoji=r) for r in vip_reactions],
+                    )
             return sent
         except (TelegramBadRequest, TelegramForbiddenError, TelegramAPIError):
             return False

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -61,6 +61,7 @@ class AdminConfigStates(StatesGroup):
     """States for bot configuration options."""
 
     waiting_for_reaction_buttons = State()
+    waiting_for_vip_reactions = State()
     waiting_for_channel_choice = State()
     waiting_for_channel_interval = State()
     waiting_for_vip_interval = State()


### PR DESCRIPTION
## Summary
- allow admins to configure default emoji reactions for VIP channel posts
- store VIP reactions via `ConfigService`
- handle new admin state and commands
- add new keyboard button
- apply reactions when sending VIP posts

## Testing
- `python -m py_compile mybot/handlers/admin/config_menu.py mybot/keyboards/admin_config_kb.py mybot/services/config_service.py mybot/services/message_service.py mybot/utils/admin_state.py`

------
https://chatgpt.com/codex/tasks/task_e_6851adc7685c8329b5a87908ebad671a