### PR TITLE
Implement role-based main menu rendering

### DIFF
--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -1,4 +1,4 @@
-from aiogram import Router, Bot
+from aiogram import Router
 from aiogram.filters import CommandStart
 from aiogram.types import Message
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,19 +6,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import User
 from utils.text_utils import sanitize_text
 
-from keyboards.admin_main_kb import get_admin_main_kb
-from keyboards.subscription_kb import get_subscription_kb
-from utils.user_roles import is_admin, is_vip_member
-from keyboards.vip_main_kb import get_vip_main_kb
-from utils.messages import BOT_MESSAGES
-from utils.menu_utils import send_menu, send_clean_message
-from services.subscription_service import SubscriptionService
+from utils.menu_utils import send_role_menu
 
 router = Router()
 
 
 @router.message(CommandStart())
-async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
+async def cmd_start(message: Message, session: AsyncSession):
     user_id = message.from_user.id
 
     # Ensure the user exists in the database so profile related features work
@@ -33,27 +27,4 @@ async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
         session.add(user)
         await session.commit()
 
-    if is_admin(user_id):
-        # Show the admin main menu directly when an administrator runs /start
-        await send_menu(
-            message,
-            "Men\u00fa de administraci\u00f3n",
-            get_admin_main_kb(),
-            session,
-            "admin_main",
-        )
-    elif await is_vip_member(bot, user_id, session=session):
-        sub_service = SubscriptionService(session)
-        sub = await sub_service.get_subscription(user_id)
-        status = "Activa" if sub else "Sin registro"
-        await send_clean_message(
-            message,
-            f"Suscripción VIP: {status}",
-            reply_markup=get_vip_main_kb(),
-        )
-    else:
-        await send_clean_message(
-            message,
-            "Bienvenido a los kinkys",
-            reply_markup=get_subscription_kb(),
-        )
+    await send_role_menu(message, session)

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -7,6 +7,7 @@ from aiogram.filters import Command
 from datetime import datetime
 
 from utils.user_roles import is_vip_member
+from utils.menu_utils import send_menu, update_menu
 from utils.keyboard_utils import (
     get_back_keyboard,
     get_main_menu_keyboard,
@@ -29,11 +30,12 @@ router = Router()
 async def vip_menu(message: Message, session: AsyncSession):
     if not await is_vip_member(message.bot, message.from_user.id, session=session):
         return
-    sub_service = SubscriptionService(session)
-    sub = await sub_service.get_subscription(message.from_user.id)
-    status = "Activa" if sub else "Sin registro"
-    await message.answer(
-        f"Suscripción VIP: {status}", reply_markup=get_vip_main_kb()
+    await send_menu(
+        message,
+        "Bienvenido al Diván de Diana",
+        get_vip_main_kb(),
+        session,
+        "vip_main",
     )
 
 
@@ -42,11 +44,12 @@ async def vip_menu_cb(callback: CallbackQuery, session: AsyncSession):
     """Return to the VIP main menu from callbacks."""
     if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
         return await callback.answer()
-    sub_service = SubscriptionService(session)
-    sub = await sub_service.get_subscription(callback.from_user.id)
-    status = "Activa" if sub else "Sin registro"
-    await callback.message.edit_text(
-        f"Suscripción VIP: {status}", reply_markup=get_vip_main_kb()
+    await update_menu(
+        callback,
+        "Bienvenido al Diván de Diana",
+        get_vip_main_kb(),
+        session,
+        "vip_main",
     )
     await callback.answer()
 

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -5,8 +5,8 @@ def get_subscription_kb():
     """Return the menu keyboard for free users."""
 
     builder = InlineKeyboardBuilder()
-    builder.button(text="Información", callback_data="free_info")
-    builder.button(text="Minijuego Kinky", callback_data="free_game")
+    builder.button(text="ℹ️ Información", callback_data="free_info")
+    builder.button(text="🧩 Mini Juego Kinky", callback_data="free_game")
     builder.adjust(1)
     return builder.as_markup()
 

--- a/mybot/keyboards/vip_main_kb.py
+++ b/mybot/keyboards/vip_main_kb.py
@@ -4,7 +4,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_vip_main_kb():
     """Return the root VIP menu keyboard."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="🧾 Mi Suscripción VIP", callback_data="vip_subscription")
-    builder.button(text="🎮 Juego Kinki", callback_data="vip_game")
+    builder.button(text="📄 Mi Suscripción", callback_data="vip_subscription")
+    builder.button(text="🎮 Juego Kinky", callback_data="vip_game")
     builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- add helper `send_role_menu` to render menus dynamically
- simplify `/start` handler to use new helper
- update VIP menu callbacks to use new titles
- tweak button labels for VIP and free users

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851b10c5ea883298f0a233ef85d3129