### PR TITLE
Implement role-based main menu rendering

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -38,7 +38,7 @@ class User(AsyncAttrs, Base):
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
 
     # Role management and VIP expiration
-    role = Column(String, default="free")
+    role = Column(String, default="Usuario Free")
     vip_expires_at = Column(DateTime, nullable=True)
     last_reminder_sent_at = Column(DateTime, nullable=True)
 

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -1,4 +1,4 @@
-from aiogram import Router, Bot
+from aiogram import Router
 from aiogram.filters import CommandStart
 from aiogram.types import Message
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,19 +6,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import User
 from utils.text_utils import sanitize_text
 
-from keyboards.admin_main_kb import get_admin_main_kb
-from keyboards.subscription_kb import get_subscription_kb
-from utils.user_roles import is_admin, is_vip_member
-from keyboards.vip_main_kb import get_vip_main_kb
-from utils.messages import BOT_MESSAGES
-from utils.menu_utils import send_menu, send_clean_message
-from services.subscription_service import SubscriptionService
+from utils.menu_utils import send_role_menu
 
 router = Router()
 
 
 @router.message(CommandStart())
-async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
+async def cmd_start(message: Message, session: AsyncSession):
     user_id = message.from_user.id
 
     # Ensure the user exists in the database so profile related features work
@@ -33,27 +27,4 @@ async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
         session.add(user)
         await session.commit()
 
-    if is_admin(user_id):
-        # Show the admin main menu directly when an administrator runs /start
-        await send_menu(
-            message,
-            "Men\u00fa de administraci\u00f3n",
-            get_admin_main_kb(),
-            session,
-            "admin_main",
-        )
-    elif await is_vip_member(bot, user_id, session=session):
-        sub_service = SubscriptionService(session)
-        sub = await sub_service.get_subscription(user_id)
-        status = "Activa" if sub else "Sin registro"
-        await send_clean_message(
-            message,
-            f"Suscripción VIP: {status}",
-            reply_markup=get_vip_main_kb(),
-        )
-    else:
-        await send_clean_message(
-            message,
-            "Bienvenido a los kinkys",
-            reply_markup=get_subscription_kb(),
-        )
+    await send_role_menu(message, session)

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -10,6 +10,7 @@ from utils.text_utils import sanitize_text
 from services.token_service import TokenService
 from services.subscription_service import SubscriptionService
 from utils.menu_utils import send_temporary_reply
+from utils.user_roles import VIP_ROLE
 from services.achievement_service import AchievementService
 from services.config_service import ConfigService
 
@@ -40,7 +41,7 @@ async def start_with_token(message: Message, command: CommandObject, session: As
         )
         session.add(user)
 
-    user.role = "vip"
+    user.role = VIP_ROLE
     expires_at = datetime.utcnow() + timedelta(days=duration)
     user.vip_expires_at = expires_at
     user.last_reminder_sent_at = None

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -7,6 +7,7 @@ from aiogram.filters import Command
 from datetime import datetime
 
 from utils.user_roles import is_vip_member
+from utils.menu_utils import send_menu, update_menu
 from utils.keyboard_utils import (
     get_back_keyboard,
     get_main_menu_keyboard,
@@ -29,11 +30,12 @@ router = Router()
 async def vip_menu(message: Message, session: AsyncSession):
     if not await is_vip_member(message.bot, message.from_user.id, session=session):
         return
-    sub_service = SubscriptionService(session)
-    sub = await sub_service.get_subscription(message.from_user.id)
-    status = "Activa" if sub else "Sin registro"
-    await message.answer(
-        f"Suscripción VIP: {status}", reply_markup=get_vip_main_kb()
+    await send_menu(
+        message,
+        "Bienvenido al Diván de Diana",
+        get_vip_main_kb(),
+        session,
+        "vip_main",
     )
 
 
@@ -42,11 +44,12 @@ async def vip_menu_cb(callback: CallbackQuery, session: AsyncSession):
     """Return to the VIP main menu from callbacks."""
     if not await is_vip_member(callback.bot, callback.from_user.id, session=session):
         return await callback.answer()
-    sub_service = SubscriptionService(session)
-    sub = await sub_service.get_subscription(callback.from_user.id)
-    status = "Activa" if sub else "Sin registro"
-    await callback.message.edit_text(
-        f"Suscripción VIP: {status}", reply_markup=get_vip_main_kb()
+    await update_menu(
+        callback,
+        "Bienvenido al Diván de Diana",
+        get_vip_main_kb(),
+        session,
+        "vip_main",
     )
     await callback.answer()
 

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -5,8 +5,8 @@ def get_subscription_kb():
     """Return the menu keyboard for free users."""
 
     builder = InlineKeyboardBuilder()
-    builder.button(text="Información", callback_data="free_info")
-    builder.button(text="Minijuego Kinky", callback_data="free_game")
+    builder.button(text="ℹ️ Información", callback_data="free_info")
+    builder.button(text="🧩 Mini Juego Kinky", callback_data="free_game")
     builder.adjust(1)
     return builder.as_markup()
 

--- a/mybot/keyboards/vip_main_kb.py
+++ b/mybot/keyboards/vip_main_kb.py
@@ -4,7 +4,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_vip_main_kb():
     """Return the root VIP menu keyboard."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="🧾 Mi Suscripción VIP", callback_data="vip_subscription")
-    builder.button(text="🎮 Juego Kinki", callback_data="vip_game")
+    builder.button(text="📄 Mi Suscripción", callback_data="vip_subscription")
+    builder.button(text="🎮 Juego Kinky", callback_data="vip_game")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/services/scheduler.py
+++ b/mybot/services/scheduler.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 
 from database.models import PendingChannelRequest, BotConfig, User
 from utils.config import CHANNEL_SCHEDULER_INTERVAL, VIP_SCHEDULER_INTERVAL
+from utils.user_roles import FREE_ROLE, VIP_ROLE
 from services.config_service import ConfigService
 
 
@@ -66,7 +67,7 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
         if not farewell_msg:
             farewell_msg = "Tu suscripción VIP ha expirado."
         stmt = select(User).where(
-            User.role == "vip",
+            User.role == VIP_ROLE,
             User.vip_expires_at <= remind_threshold,
             User.vip_expires_at > now,
             (User.last_reminder_sent_at.is_(None))
@@ -83,7 +84,7 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
                 logging.exception("Failed to send reminder to %s: %s", user.id, e)
 
         stmt = select(User).where(
-            User.role == "vip",
+            User.role == VIP_ROLE,
             User.vip_expires_at.is_not(None),
             User.vip_expires_at <= now,
         )
@@ -96,7 +97,7 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
                     await bot.kick_chat_member(vip_channel_id, user.id)
             except Exception as e:
                 logging.exception("Failed to remove %s from VIP channel: %s", user.id, e)
-            user.role = "free"
+            user.role = FREE_ROLE
             await bot.send_message(user.id, farewell_msg)
             logging.info("VIP expired for %s", user.id)
         await session.commit()

--- a/mybot/services/subscription_service.py
+++ b/mybot/services/subscription_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 
 from database.models import VipSubscription, User, Token, Tariff
+from utils.user_roles import VIP_ROLE, FREE_ROLE
 
 
 class SubscriptionService:
@@ -84,7 +85,7 @@ class SubscriptionService:
 
         user = await self.session.get(User, user_id)
         if user:
-            user.role = "vip"
+            user.role = VIP_ROLE
             if user.vip_expires_at and user.vip_expires_at > now:
                 user.vip_expires_at = user.vip_expires_at + timedelta(days=days)
             else:
@@ -103,7 +104,7 @@ class SubscriptionService:
 
         user = await self.session.get(User, user_id)
         if user:
-            user.role = "free"
+            user.role = FREE_ROLE
             user.vip_expires_at = None
 
         await self.session.commit()

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -3,6 +3,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .config import ADMIN_IDS, VIP_CHANNEL_ID
 import os
 
+# Constants for role identifiers
+ADMIN_ROLE = "admin"
+VIP_ROLE = "vip"
+FREE_ROLE = "Usuario Free"
+
 DEFAULT_VIP_MULTIPLIER = int(os.environ.get("VIP_POINTS_MULTIPLIER", "2"))
 
 
@@ -40,6 +45,17 @@ async def get_points_multiplier(bot: Bot, user_id: int, session: AsyncSession | 
     if await is_vip_member(bot, user_id, session=session):
         return DEFAULT_VIP_MULTIPLIER
     return 1
+
+
+async def get_user_role(
+    bot: Bot, user_id: int, session: AsyncSession | None = None
+) -> str:
+    """Return the textual role of the user."""
+    if is_admin(user_id):
+        return ADMIN_ROLE
+    if await is_vip_member(bot, user_id, session=session):
+        return VIP_ROLE
+    return FREE_ROLE
 
 
 # Backwards compatibility


### PR DESCRIPTION
## Summary
- define role constants and helper `get_user_role`
- refactor `send_role_menu` to rely on the new helper
- use role constants when updating user roles
- default DB role is now `Usuario Free`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851b10c5ea883298f0a233ef85d3129