### PR TITLE
Merge PR-155 with resolved menu constant conflicts

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -38,7 +38,7 @@ class User(AsyncAttrs, Base):
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
 
     # Role management and VIP expiration
-    role = Column(String, default="free")
+    role = Column(String, default="Usuario Free")
     vip_expires_at = Column(DateTime, nullable=True)
     last_reminder_sent_at = Column(DateTime, nullable=True)
 

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -10,6 +10,7 @@ from utils.text_utils import sanitize_text
 from services.token_service import TokenService
 from services.subscription_service import SubscriptionService
 from utils.menu_utils import send_temporary_reply
+from utils.user_roles import VIP_ROLE
 from services.achievement_service import AchievementService
 from services.config_service import ConfigService
 
@@ -40,7 +41,7 @@ async def start_with_token(message: Message, command: CommandObject, session: As
         )
         session.add(user)
 
-    user.role = "vip"
+    user.role = VIP_ROLE
     expires_at = datetime.utcnow() + timedelta(days=duration)
     user.vip_expires_at = expires_at
     user.last_reminder_sent_at = None

--- a/mybot/services/scheduler.py
+++ b/mybot/services/scheduler.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 
 from database.models import PendingChannelRequest, BotConfig, User
 from utils.config import CHANNEL_SCHEDULER_INTERVAL, VIP_SCHEDULER_INTERVAL
+from utils.user_roles import FREE_ROLE, VIP_ROLE
 from services.config_service import ConfigService
 
 
@@ -66,7 +67,7 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
         if not farewell_msg:
             farewell_msg = "Tu suscripción VIP ha expirado."
         stmt = select(User).where(
-            User.role == "vip",
+            User.role == VIP_ROLE,
             User.vip_expires_at <= remind_threshold,
             User.vip_expires_at > now,
             (User.last_reminder_sent_at.is_(None))
@@ -83,7 +84,7 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
                 logging.exception("Failed to send reminder to %s: %s", user.id, e)
 
         stmt = select(User).where(
-            User.role == "vip",
+            User.role == VIP_ROLE,
             User.vip_expires_at.is_not(None),
             User.vip_expires_at <= now,
         )
@@ -96,7 +97,7 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
                     await bot.kick_chat_member(vip_channel_id, user.id)
             except Exception as e:
                 logging.exception("Failed to remove %s from VIP channel: %s", user.id, e)
-            user.role = "free"
+            user.role = FREE_ROLE
             await bot.send_message(user.id, farewell_msg)
             logging.info("VIP expired for %s", user.id)
         await session.commit()

--- a/mybot/services/subscription_service.py
+++ b/mybot/services/subscription_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 
 from database.models import VipSubscription, User, Token, Tariff
+from utils.user_roles import VIP_ROLE, FREE_ROLE
 
 
 class SubscriptionService:
@@ -84,7 +85,7 @@ class SubscriptionService:
 
         user = await self.session.get(User, user_id)
         if user:
-            user.role = "vip"
+            user.role = VIP_ROLE
             if user.vip_expires_at and user.vip_expires_at > now:
                 user.vip_expires_at = user.vip_expires_at + timedelta(days=days)
             else:
@@ -103,7 +104,7 @@ class SubscriptionService:
 
         user = await self.session.get(User, user_id)
         if user:
-            user.role = "free"
+            user.role = FREE_ROLE
             user.vip_expires_at = None
 
         await self.session.commit()

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -3,6 +3,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .config import ADMIN_IDS, VIP_CHANNEL_ID
 import os
 
+# Constants for role identifiers
+ADMIN_ROLE = "admin"
+VIP_ROLE = "vip"
+FREE_ROLE = "Usuario Free"
+
 DEFAULT_VIP_MULTIPLIER = int(os.environ.get("VIP_POINTS_MULTIPLIER", "2"))
 
 
@@ -40,6 +45,17 @@ async def get_points_multiplier(bot: Bot, user_id: int, session: AsyncSession | 
     if await is_vip_member(bot, user_id, session=session):
         return DEFAULT_VIP_MULTIPLIER
     return 1
+
+
+async def get_user_role(
+    bot: Bot, user_id: int, session: AsyncSession | None = None
+) -> str:
+    """Return the textual role of the user."""
+    if is_admin(user_id):
+        return ADMIN_ROLE
+    if await is_vip_member(bot, user_id, session=session):
+        return VIP_ROLE
+    return FREE_ROLE
 
 
 # Backwards compatibility


### PR DESCRIPTION
## Summary
- resolve merge conflicts from upstream PR 155
- replace role strings with constants across modules
- update menu handling to use `get_user_role`

## Testing
- `python -m py_compile mybot/database/models.py mybot/handlers/user/start_token.py mybot/services/scheduler.py mybot/services/subscription_service.py mybot/utils/menu_utils.py mybot/utils/user_roles.py`

------
https://chatgpt.com/codex/tasks/task_e_6851c6735b048329996dd46e88c480b4