### PR TITLE
Fix VIP menu missing import

### DIFF
--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -7,7 +7,7 @@ from aiogram.filters import Command
 from datetime import datetime
 
 from utils.user_roles import is_vip_member
-from utils.menu_utils import send_menu, update_menu
+from utils.menu_utils import send_menu, update_menu, send_temporary_reply
 from utils.keyboard_utils import (
     get_back_keyboard,
     get_main_menu_keyboard,


### PR DESCRIPTION
## Summary
- add missing `send_temporary_reply` import

## Testing
- `pyflakes mybot/handlers/vip/menu.py`
- `python -m compileall -q mybot`

------
https://chatgpt.com/codex/tasks/task_e_6851e0b62b54832981a30adfa1d3ce4d